### PR TITLE
좌석 추가, 예약 추가 테스트 코드 실패 오류 수정

### DIFF
--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatAddControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatAddControllerTest.java
@@ -66,7 +66,7 @@ class SeatAddControllerTest {
             @Test
             void test() throws Exception {
                 subject().andExpect(status().isCreated())
-                        .andExpect(jsonPath("$.seatNumber").value(SEAT_NUMBER));
+                        .andExpect(jsonPath("$.number").value(SEAT_NUMBER));
             }
         }
     }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationServiceTest.java
@@ -86,12 +86,13 @@ class SeatReservationServiceTest {
 
             @Test
             void test() {
-                assertThat(subject().getId()).isEqualTo(SEAT_RESERVATION_ID);
-                assertThat(subject().getSeatNumber()).isEqualTo(SEAT_NUMBER);
-                assertThat(subject().getUserName()).isEqualTo(USER_NAME);
-                assertThat(subject().getDate()).isEqualTo(DATE);
-                assertThat(subject().getCheckIn()).isEqualTo(CHECK_IN);
-                assertThat(subject().getCheckOut()).isEqualTo(CHECK_OUT);
+                SeatReservation seatReservation = subject();
+                assertThat(seatReservation.getId()).isEqualTo(SEAT_RESERVATION_ID);
+                assertThat(seatReservation.getSeatNumber()).isEqualTo(SEAT_NUMBER);
+                assertThat(seatReservation.getUserName()).isEqualTo(USER_NAME);
+                assertThat(seatReservation.getDate()).isEqualTo(DATE);
+                assertThat(seatReservation.getCheckIn()).isEqualTo(CHECK_IN);
+                assertThat(seatReservation.getCheckOut()).isEqualTo(CHECK_OUT);
             }
         }
     }


### PR DESCRIPTION
## 작업 내용
- https://github.com/CodeSoom-Project/my-seat/issues/9 해당 오류를 수정했습니다.
- 좌석 추가 테스트 코드의 실패 원인은 좌석 추가 요청에 대한 응답 값 중 좌석 번호가 seatNumber로 잘못 표기되어 있었기 때문이었고, 이를 number로 수정하여 해결했습니다.
- 좌석 예약 추가 테스트 코드의 실패 원인은 한 좌석에 대해 addReservation() 메서드가 두 번 이상 호출될 경우 해당 좌석의 예약 여부를 확인하는 함수에서 예외를 발생시키기 때문이었고, addReservation() 메서드가 여러 번 호출되지 않도록 수정하여 해결했습니다.