### PR TITLE
생성된 REST Docs html 문서를 static/docs로 복사하는 설정 추가

### DIFF
--- a/app-server/app/build.gradle
+++ b/app-server/app/build.gradle
@@ -23,6 +23,10 @@ configurations {
     asciidoctorExtensions
 }
 
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
 dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
@@ -69,11 +73,21 @@ application {
     mainClass = 'com.codesoom.myseat.App'
 }
 
-tasks.named('test') {
-    // Use junit platform for unit tests.
+test {
+    outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
 asciidoctor {
+    configurations 'asciidoctorExtensions'
+    inputs.dir snippetsDir
     dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'src/main/resources/static/docs'
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 생성된 Rest Docs html 문서를 static/docs 디렉토리로 복사하여 /docs/index.html URL로 접근 가능하도록 설정했습니다.