### PR TITLE
좌석 예약 취소 시 상태 코드만 응답하도록 수정

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatReservationCancelController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatReservationCancelController.java
@@ -1,8 +1,6 @@
 package com.codesoom.myseat.controllers;
 
-import com.codesoom.myseat.domain.SeatReservation;
 import com.codesoom.myseat.dto.SeatReservationCancelRequest;
-import com.codesoom.myseat.dto.SeatReservationResponse;
 import com.codesoom.myseat.services.SeatReservationCancelService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -21,33 +19,17 @@ public class SeatReservationCancelController {
     }
 
     /**
-     * 좌석 예약을 취소한 후 상태코드 204와 취소된 예약 정보를 응답한다.
+     * 좌석 예약을 취소한 후 상태코드 204를 응답한다.
+     *
      * @param seatNumber 예약 취소할 좌석 번호
      * @param request 좌석 예약 취소 요청 정보
-     * @return 취소된 예약 정보
      */
     @DeleteMapping("{seatNumber}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public SeatReservationResponse cancelReservation(
+    public void cancelReservation(
             @PathVariable int seatNumber,
             @RequestBody SeatReservationCancelRequest request
     ) {
-        return toResponse(service.cancelReservation(seatNumber, request));
-    }
-
-    /**
-     * 취소된 예약 정보 DTO를 반환한다.
-     *
-     * @param data 취소된 예약 정보
-     * @return 취소된 예약 정보 DTO
-     */
-    private SeatReservationResponse toResponse(SeatReservation data) {
-        return SeatReservationResponse.builder()
-                .userName(data.getUserName())
-                .seatNumber(data.getSeatNumber())
-                .date(data.getDate())
-                .checkIn(data.getCheckIn())
-                .checkOut(data.getCheckOut())
-                .build();
+        service.cancelReservation(seatNumber, request);
     }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatReservationCancelControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatReservationCancelControllerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SeatReservationCancelController.class)
@@ -67,8 +66,7 @@ class SeatReservationCancelControllerTest {
                 .content(toJson(request)));;
 
         // then
-        subject.andExpect(status().isNoContent())
-                .andExpect(jsonPath("$.seatNumber").value(SEAT_NUMBER));
+        subject.andExpect(status().isNoContent());
     }
 
     private String toJson(Object object) throws JsonProcessingException {


### PR DESCRIPTION
## 작업 내용
- 기존에는 취소된 예약 정보를 응답했었는데, 해당 정보는 응답할 필요가 없다고 생각되어 수정했습니다.