### PR TITLE
좌석 예약 목록 조회 서비스 테스트 코드에서 List.of() 부분 컴파일 오류 수정

### DIFF
--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationListServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationListServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,7 +52,7 @@ class SeatReservationListServiceTest {
         @BeforeEach
         void setUp() {
             given(repository.findAllByDate(any(String.class)))
-                    .willReturn(List.of(seatReservation));
+                    .willReturn(Optional.of(List.of(seatReservation)));
         }
 
         @Nested


### PR DESCRIPTION
## 작업 내용
- findAllByDate()의 반환값은 Optional입니다. 그런데 null을 허용하지 않는 List.of() 메서드를 사용하려고 하니 컴파일 오류가 발생했습니다. 그래서 Optional.of()로 감싸주어 해당 오류를 해결했습니다.