### PR TITLE
좌석 상세 조회 기능 구현

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
@@ -1,0 +1,25 @@
+package com.codesoom.myseat.controllers;
+
+import com.codesoom.myseat.dto.SeatReservationResponse;
+import com.codesoom.myseat.services.SeatDetailService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 좌석 상세 조회 컨트롤러
+ */
+@RestController
+@RequestMapping("/seat")
+public class SeatDetailController {
+    private final SeatDetailService service;
+
+    public SeatDetailController(SeatDetailService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public SeatReservationResponse seatDetail(@PathVariable int seatNumber) {
+        return null;
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
@@ -1,5 +1,6 @@
 package com.codesoom.myseat.controllers;
 
+import com.codesoom.myseat.domain.SeatReservation;
 import com.codesoom.myseat.dto.SeatReservationResponse;
 import com.codesoom.myseat.services.SeatDetailService;
 import org.springframework.http.HttpStatus;
@@ -17,9 +18,31 @@ public class SeatDetailController {
         this.service = service;
     }
 
-    @GetMapping
+    /**
+     * 좌석 상세 조회 후 상태코드 200을 응답한다.
+     *
+     * @param seatNumber 조회할 좌석 번호
+     * @return 좌석 예약 정보
+     */
+    @GetMapping("{seatNumber}")
     @ResponseStatus(HttpStatus.OK)
     public SeatReservationResponse seatDetail(@PathVariable int seatNumber) {
-        return null;
+        return toResponse(service.seatDetail(seatNumber));
+    }
+
+    /**
+     * 응답 정보를 반환한다.
+     *
+     * @param data 좌석 예약 정보
+     * @return 응답 정보
+     */
+    private SeatReservationResponse toResponse(SeatReservation data) {
+        return SeatReservationResponse.builder()
+                .userName(data.getUserName())
+                .seatNumber(data.getSeatNumber())
+                .date(data.getDate())
+                .checkIn(data.getCheckIn())
+                .checkOut(data.getCheckOut())
+                .build();
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservationRepository.java
@@ -40,4 +40,13 @@ public interface SeatReservationRepository
      * @param s must not be {@literal null}. 삭제할 좌석 예약 정보
      */
     void delete(SeatReservation s);
+
+    /**
+     * 특정 좌석의 당일 예약 정보를 반환한다.
+     *
+     * @param today 오늘 날짜
+     * @param seatNumber 좌석 번호
+     * @return 좌석 예약 정보
+     */
+    Optional<SeatReservation> findByDateAndSeatNumber(String today, int seatNumber);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
@@ -1,0 +1,21 @@
+package com.codesoom.myseat.services;
+
+import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.domain.SeatReservationRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * 좌석 상세 조회 서비스
+ */
+@Service
+public class SeatDetailService {
+    private final SeatReservationRepository repository;
+
+    public SeatDetailService(SeatReservationRepository repository) {
+        this.repository = repository;
+    }
+
+    public SeatReservation seatDetail(int seatNumber) {
+        return null;
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
@@ -2,7 +2,11 @@ package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.SeatReservation;
 import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.exceptions.SeatReservationNotFoundException;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * 좌석 상세 조회 서비스
@@ -15,8 +19,26 @@ public class SeatDetailService {
         this.repository = repository;
     }
 
+    /**
+     * 좌석의 당일 예약 정보를 반환한다.
+     *
+     * @param seatNumber 좌석 번호
+     * @return 당일 예약 정보
+     * @throws SeatReservationNotFoundException 예약 내역을 찾을 수 없는 경우 예외를 던진다.
+     */
     public SeatReservation seatDetail(int seatNumber) {
-        // TODO: 해당 좌석의 당일 예약 정보를 반환해야 한다.
-        return null;
+        return repository.findByDateAndSeatNumber(today(), seatNumber)
+                .orElseThrow(() -> new SeatReservationNotFoundException(
+                        "당일 예약 내역을 찾을 수 없어서 조회에 실패했습니다."));
+    }
+
+    /**
+     * 오늘 날짜를 반환한다.
+     *
+     * @return 오늘 날짜
+     */
+    private String today() {
+        LocalDateTime now = LocalDateTime.now();
+        return now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
@@ -16,6 +16,7 @@ public class SeatDetailService {
     }
 
     public SeatReservation seatDetail(int seatNumber) {
+        // TODO: 해당 좌석의 당일 예약 정보를 반환해야 한다.
         return null;
     }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
@@ -1,0 +1,63 @@
+package com.codesoom.myseat.controllers;
+
+import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.services.SeatDetailService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SeatDetailController.class)
+@AutoConfigureRestDocs(uriScheme = "http", uriHost = "15.164.164.136", uriPort = 8080)
+class SeatDetailControllerTest {
+    private static final int SEAT_NUMBER = 3;
+    private static final String USER_NAME = "코드숨";
+    private static final Long SEAT_RESERVATION_ID = 1L;
+    private static final String DATE = "2022-07-18";
+    private static final String CHECK_IN = "09:30";
+    private static final String CHECK_OUT = "17:30";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SeatDetailService service;
+
+    private SeatReservation reservation;
+
+    @Test
+    @DisplayName("좌석 상세 조회 요청 테스트")
+    void test() throws Exception {
+        // given
+        reservation = SeatReservation.builder()
+                .id(SEAT_RESERVATION_ID)
+                .seatNumber(SEAT_NUMBER)
+                .userName(USER_NAME)
+                .date(DATE)
+                .checkIn(CHECK_IN)
+                .checkOut(CHECK_OUT)
+                .build();
+
+        given(service.seatDetail(SEAT_NUMBER)).willReturn(reservation);
+
+        // when
+        ResultActions subject = mockMvc.perform(get("/seat/{seatNumber}", SEAT_NUMBER));
+
+        // then
+        subject.andExpect(status().isOk())
+                .andExpect(jsonPath("$.seatNumber").value(SEAT_NUMBER))
+                .andExpect(jsonPath("$.userName").value(USER_NAME))
+                .andExpect(jsonPath("$.date").value(DATE))
+                .andExpect(jsonPath("$.checkIn").value(CHECK_IN))
+                .andExpect(jsonPath("$.checkOut").value(CHECK_OUT));
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatDetailServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatDetailServiceTest.java
@@ -1,0 +1,78 @@
+package com.codesoom.myseat.services;
+
+import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.domain.SeatReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class SeatDetailServiceTest {
+    private static final int SEAT_NUMBER = 3;
+    private static final String USER_NAME = "코드숨";
+    private static final Long SEAT_RESERVATION_ID = 1L;
+    private static final String DATE = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    private static final String CHECK_IN = "09:30";
+    private static final String CHECK_OUT = "17:30";
+
+    private SeatDetailService service;
+
+    private final SeatReservationRepository repository
+            = mock(SeatReservationRepository.class);
+
+    private SeatReservation seatReservation;
+
+    @BeforeEach
+    void setUp() {
+        service = new SeatDetailService(repository);
+
+        seatReservation = SeatReservation.builder()
+                .id(SEAT_RESERVATION_ID)
+                .seatNumber(SEAT_NUMBER)
+                .userName(USER_NAME)
+                .date(DATE)
+                .checkIn(CHECK_IN)
+                .checkOut(CHECK_OUT)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("seatDetail 메서드는")
+    class Describe_seatReservations_method {
+        @BeforeEach
+        void setUp() {
+            given(repository.findByDateAndSeatNumber(any(String.class), eq(SEAT_NUMBER)))
+                    .willReturn(Optional.of(seatReservation));
+        }
+
+        @Nested
+        @DisplayName("좌석의 당일 예약 정보를 반환한다.")
+        class It_returns_seat_reservation_data_of_today {
+            SeatReservation subject() {
+                return service.seatDetail(SEAT_NUMBER);
+            }
+
+            @Test
+            void test() {
+                SeatReservation seatReservation = subject();
+
+                assertThat(seatReservation.getId()).isEqualTo(SEAT_RESERVATION_ID);
+                assertThat(seatReservation.getSeatNumber()).isEqualTo(SEAT_NUMBER);
+                assertThat(seatReservation.getUserName()).isEqualTo(USER_NAME);
+                assertThat(seatReservation.getDate()).isEqualTo(DATE);
+                assertThat(seatReservation.getCheckIn()).isEqualTo(CHECK_IN);
+                assertThat(seatReservation.getCheckOut()).isEqualTo(CHECK_OUT);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 좌석 상세 조회 기능을 구현했습니다.
- 특정 좌석의 당일 예약 정보를 알 수 있습니다.

## 실행 예시
1번 좌석에 대한 과거부터 현재까지의 예약 내역이 아래와 같을 때,

![image](https://user-images.githubusercontent.com/98736689/179471494-394e9e5e-9c49-46b3-be7c-1b0d64bf95cc.png)

22년 7월 18일에 1번 좌석에 대한 상세 조회 요청을 할 경우
아래와 같이 7월 18일의 예약 정보만 응답합니다.

![image](https://user-images.githubusercontent.com/98736689/179471580-51881858-2dea-4e82-b8bf-a65ec1c78547.png)
