### PR TITLE
working directory 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,11 @@ on:
 permissions:
   contents: read
 
-defaults:
-    run:
-      working-directory: my-seat/app-server
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./app-server
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## 작업 내용
기존에는 working directory를 `my-seat/app-server`로 설정했었는데, workflow 실행 시 아래 오류가 발생했습니다.

```bash
Error: Cannot locate a Gradle wrapper properties file at '/home/runner/work/my-seat/my-seat/gradle/wrapper/gradle-wrapper.properties'. Specify 'gradle-version' or 'gradle-executable' for projects without Gradle wrapper configured.
```

`/my-seat/my-seat/`으로 경로가 중복되어 발생한 오류이므로 working directory를 `./app-server`로 수정했습니다.