### PR TITLE
MockMvcRequestBuilders를 RestDocumentationBuilders로수정

### DIFF
--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
@@ -14,13 +14,13 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 


### PR DESCRIPTION
## 작업 내용
- 공식 문서에 따르면 Path parameters를 문서에 사용하고 싶은 경우 RestDocumentationBuilders를 사용하도록 권장하고 있습니다. 따라서 기존에 MockMvcRequestBuilders의 get 메서드를 사용하고 있던 것을 RestDocumentationBuilders의 get 메서드로 수정했습니다.