### PR TITLE
예약 내역이 없는 경우 상태 코드 200을 응답하도록 수정

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -44,7 +44,7 @@ public class ControllerErrorAdvice {
      *
      * @return 에러메시지
      */
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.OK)
     @ExceptionHandler(SeatReservationNotFoundException.class)
     public ErrorResponse handleSeatReservationNotFound() {
         return new ErrorResponse("좌석 예약 목록을 찾을 수 없습니다.");


### PR DESCRIPTION
## 작업 내용
- 기존에는 예약 내역이 DB에 저장된 예약 내역이 없는 경우 예약 목록 조회 시 상태 코드 404를 응답했었는데, 데이터가 없을 뿐 조회에는 성공한 것이므로 상태 코드 200을 응답하도록 수정했습니다.