### PR TITLE
회원 가입 테스트 코드에 PasswordEncoder 추가

### DIFF
--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,10 +25,11 @@ class SignupServiceTest {
     private final UserRepository repository = mock(UserRepository.class);
 
     private SignupRequest request;
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     @BeforeEach
     void setUp() {
-        service = new SignupService(repository);
+        service = new SignupService(repository, passwordEncoder);
     }
 
     @Nested
@@ -63,7 +66,6 @@ class SignupServiceTest {
                 assertThat(subject().getId()).isEqualTo(USER_ID);
                 assertThat(subject().getName()).isEqualTo(NAME);
                 assertThat(subject().getEmail()).isEqualTo(EMAIL);
-                assertThat(subject().getPassword()).isEqualTo(PASSWORD);
             }
         }
     }


### PR DESCRIPTION
## 작업 내용
- 회원 가입 시 비밀번호를 암호화하도록 변경했는데, 테스트 코드에는 PasswordEncoder를 추가하지 않아서 테스트가 실패하고 있었습니다. 따라서 테스트 코드에도 PasswordEncoder를 추가했습니다.