### PR TITLE
엔티티 간 연관 관계 매핑, 로그인 로직 수정

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -1,10 +1,7 @@
 package com.codesoom.myseat.controllers;
 
 import com.codesoom.myseat.dto.ErrorResponse;
-import com.codesoom.myseat.exceptions.SeatAlreadyReservedException;
-import com.codesoom.myseat.exceptions.SeatNotFoundException;
-import com.codesoom.myseat.exceptions.SeatReservationNotFoundException;
-import com.codesoom.myseat.exceptions.UserAlreadyReservedSeatTodayException;
+import com.codesoom.myseat.exceptions.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -61,5 +58,16 @@ public class ControllerErrorAdvice {
     @ExceptionHandler(UserAlreadyReservedSeatTodayException.class)
     public ErrorResponse handleUserAlreadyReservedSeatToday() {
         return new ErrorResponse("당일 예약 내역이 존재하여 예약이 불가합니다");
+    }
+
+    /**
+     * 로그인에 실패했을 때 에러메시지를 반환한다.
+     * 
+     * @return 에러메시지
+     */
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(LoginFailureException.class)
+    public ErrorResponse handleLoginFailure() {
+        return new ErrorResponse("로그인에 실패했습니다.");
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/LoginController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/LoginController.java
@@ -1,5 +1,6 @@
 package com.codesoom.myseat.controllers;
 
+import com.codesoom.myseat.domain.Token;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.dto.LoginResponse;
 import com.codesoom.myseat.services.LoginService;
@@ -40,9 +41,9 @@ public class LoginController {
      * @param token 토큰
      * @return 응답 정보
      */
-    private LoginResponse toResponse(String token) {
+    private LoginResponse toResponse(Token token) {
         return LoginResponse.builder()
-                .token(token)
+                .token(token.getToken())
                 .build();
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Seat.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Seat.java
@@ -5,9 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 /**
  * 좌석 엔티티
@@ -20,6 +18,7 @@ import javax.persistence.Id;
 public class Seat {
     @Id
     @GeneratedValue
+    @Column(name="seat_id")
     private Long id;
 
     private int number;
@@ -29,6 +28,9 @@ public class Seat {
 
     @Builder.Default
     private String userName = "";
+
+    @OneToOne(mappedBy = "seat")
+    private SeatReservation seatReservation;
 
     public void reserve(String userName) {
         this.isReserved = true; 

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservation.java
@@ -23,8 +23,6 @@ public class SeatReservation {
     @Column(name="seatReservation_id")
     private Long id;
 
-    private int seatNumber;
-
     private String date;
 
     private String checkIn;
@@ -34,4 +32,8 @@ public class SeatReservation {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToOne
+    @JoinColumn(name = "seat_id")
+    private Seat seat;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/SeatReservation.java
@@ -5,9 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 좌석 예약 엔티티
@@ -20,15 +20,18 @@ import javax.persistence.Id;
 public class SeatReservation {
     @Id
     @GeneratedValue
+    @Column(name="seatReservation_id")
     private Long id;
 
     private int seatNumber;
-
-    private String userName;
 
     private String date;
 
     private String checkIn;
 
     private String checkOut;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Token.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Token.java
@@ -1,0 +1,28 @@
+package com.codesoom.myseat.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+/**
+ * 토큰 엔티티
+ */
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Token {
+    @Id
+    @GeneratedValue
+    @Column(name = "token_id")
+    private Long id;
+
+    private String token;
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Token.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Token.java
@@ -5,10 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 /**
  * 토큰 엔티티
@@ -25,4 +22,7 @@ public class Token {
     private Long id;
 
     private String token;
+
+    @OneToOne(mappedBy = "token")
+    private User user;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -45,4 +45,13 @@ public class User {
     ) {
         return encoder.matches(password, this.password);
     }
+
+    /**
+     * 토큰을 갱신 한다.
+     * 
+     * @param token 토큰
+     */
+    public void updateToken(Token token) {
+        this.token = token;
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 회원 엔티티
@@ -31,6 +33,9 @@ public class User {
     @OneToOne
     @JoinColumn(name = "token_id")
     private Token token;
+
+    @OneToMany(mappedBy = "user")
+    private List<SeatReservation> seatReservations = new ArrayList<>();
 
     /**
      * 비밀번호를 인증한다.

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 
@@ -35,9 +36,13 @@ public class User {
      * 비밀번호를 인증한다.
      * 
      * @param password 인증할 비밀번호
+     * @param encoder 비밀번호 인코더
      * @return 엔티티의 비밀번호와 일치하면 true, 일치하지 않으면 false
      */
-    public boolean authenticate(String password) {
-        return this.password.equals(password); 
+    public boolean authenticate(
+            String password,
+            PasswordEncoder encoder
+    ) {
+        return encoder.matches(password, this.password);
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -5,9 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 /**
  * 회원 엔티티
@@ -20,6 +18,7 @@ import javax.persistence.Id;
 public class User {
     @Id
     @GeneratedValue
+    @Column(name="user_id")
     private Long id;
 
     private String name;
@@ -27,6 +26,10 @@ public class User {
     private String email;
     
     private String password;
+
+    @OneToOne
+    @JoinColumn(name = "token_id")
+    private Token token;
 
     /**
      * 비밀번호를 인증한다.

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/SeatRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/SeatRepository.java
@@ -1,5 +1,6 @@
-package com.codesoom.myseat.domain;
+package com.codesoom.myseat.repositories;
 
+import com.codesoom.myseat.domain.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/SeatReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/SeatReservationRepository.java
@@ -1,5 +1,6 @@
-package com.codesoom.myseat.domain;
+package com.codesoom.myseat.repositories;
 
+import com.codesoom.myseat.domain.SeatReservation;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/TokenRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/TokenRepository.java
@@ -1,0 +1,18 @@
+package com.codesoom.myseat.repositories;
+
+import com.codesoom.myseat.domain.Token;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 토큰 레포지토리
+ */
+public interface TokenRepository
+        extends JpaRepository<Token, Long> {
+    /**
+     * 토큰을 저장한다.
+     * 
+     * @param token must not be {@literal null}. 저장할 토큰 정보
+     * @return 토큰
+     */
+    Token save(Token token);
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
@@ -1,6 +1,7 @@
-package com.codesoom.myseat.domain;
+package com.codesoom.myseat.repositories;
 
-import org.springframework.data.repository.CrudRepository;
+import com.codesoom.myseat.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
@@ -8,7 +9,7 @@ import java.util.Optional;
  * 회원 레포지토리
  */
 public interface UserRepository 
-        extends CrudRepository<User, Long> {
+        extends JpaRepository<User, Long> {
 
     /**
      * 회원 정보를 저장한다.

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/LoginService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/LoginService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.domain.UserRepository;
+import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.exceptions.LoginFailureException;
 import com.codesoom.myseat.exceptions.UserNotFoundException;

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/LoginService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/LoginService.java
@@ -1,11 +1,14 @@
 package com.codesoom.myseat.services;
 
+import com.codesoom.myseat.domain.Token;
 import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.repositories.TokenRepository;
 import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.exceptions.LoginFailureException;
 import com.codesoom.myseat.exceptions.UserNotFoundException;
 import com.codesoom.myseat.utils.TokenProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 /**
@@ -13,34 +16,46 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class LoginService {
-    private final UserRepository repository;
+    private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    private final TokenRepository tokenRepository;
+    private final PasswordEncoder encoder;
 
-    public LoginService(UserRepository repository, TokenProvider tokenProvider) {
-        this.repository = repository;
+    public LoginService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            TokenRepository tokenRepository,
+            PasswordEncoder encoder
+    ) {
+        this.userRepository = userRepository;
         this.tokenProvider = tokenProvider;
+        this.tokenRepository = tokenRepository;
+        this.encoder = encoder;
     }
 
     /**
      * 로그인 후 토큰을 반환한다.
+     * 
      * @param request 로그인 요청 정보
      * @return 토큰
      * @throws LoginFailureException 비밀번호 인증에 실패한 경우 예외를 던진다.
      * @throws UserNotFoundException 회원을 찾을 수 없는 경우 예외를 던진다.
      */
-    public String login(LoginRequest request) {
-        // TODO: 인증
-        //  - 로그인 dto의 비밀번호가 회원 정보와 일치하는지 확인
-        //  - 일치하면 유효한 토큰 반환
-        //  - 일치하지 않으면 예외 던짐
+    public Token login(LoginRequest request) {
         User user = user(request.getEmail());
-        
-        if(!user.authenticate(request.getPassword())) { // 비밀번호 인증 실패하면
+        if(!user.authenticate(request.getPassword(), encoder)) {
             throw new LoginFailureException(
                     "입력한 비밀번호 [" + request.getPassword() + "]가 회원 DB에 저장된 것과 일치하지 않습니다.");
         }
-        
-        return tokenProvider.token(request.getEmail()); // 토큰 반환
+
+        Token token = Token.builder()
+                .token(tokenProvider.token(request.getEmail()))
+                .user(user)
+                .build();
+
+        user.updateToken(token);
+
+        return tokenRepository.save(token);
     }
 
     /**
@@ -51,7 +66,7 @@ public class LoginService {
      * @throws UserNotFoundException 회원을 찾을 수 없는 경우 예외를 던진다.
      */
     private User user(String email) {
-        return repository.findByEmail(email)
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(
                         "[" + email + "]이 일치하는 회원을 찾을 수 없어서 조회에 실패했습니다."));
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatAddService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.dto.SeatAddRequest;
 import org.springframework.stereotype.Service;
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatDetailService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.exceptions.SeatReservationNotFoundException;
 import org.springframework.stereotype.Service;
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatListService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatListService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationCancelService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationCancelService.java
@@ -1,9 +1,9 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.dto.SeatReservationCancelRequest;
 import com.codesoom.myseat.exceptions.SeatNotFoundException;
 import com.codesoom.myseat.exceptions.SeatReservationNotFoundException;

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationListService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationListService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.exceptions.SeatReservationNotFoundException;
 import org.springframework.stereotype.Service;
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SeatReservationService.java
@@ -1,9 +1,9 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.dto.SeatReservationRequest;
 import com.codesoom.myseat.exceptions.SeatAlreadyReservedException;
 import com.codesoom.myseat.exceptions.SeatNotFoundException;

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SignupService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SignupService.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.domain.UserRepository;
+import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.SignupRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/app-server/app/src/main/java/com/codesoom/myseat/utils/ScheduledTasks.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/utils/ScheduledTasks.java
@@ -1,6 +1,6 @@
 package com.codesoom.myseat.utils;
 
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/LoginControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/LoginControllerTest.java
@@ -1,5 +1,7 @@
 package com.codesoom.myseat.controllers;
 
+import com.codesoom.myseat.domain.Token;
+import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.services.LoginService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,8 +33,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(LoginController.class)
 @AutoConfigureRestDocs(uriScheme = "https", uriHost = "api.codesoom-myseat.site")
 class LoginControllerTest {
-    private static final String EMAIL = "test@example.com";
-    private static final String PASSWORD = "test";
+    private static final Long USER_ID = 1L;
+    private static final String USER_NAME = "코드숨";
+    private static final String USER_EMAIL = "test@example.com";
+    private static final String USER_PASSWORD = "1234";
+    private static final Long TOKEN_ID = 2L;
     private static final String TOKEN = "eyJhbGciOiJIUzI1NiJ9" +
             ".eyJ1c2VySWQiOjF9" +
             ".ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
@@ -44,18 +49,33 @@ class LoginControllerTest {
     private LoginService service;
 
     private LoginRequest request;
+    private User user;
+    private Token token;
 
     @Test
     @DisplayName("로그인 테스트")
     void test() throws Exception {
         // given
         request = LoginRequest.builder()
-                .email(EMAIL)
-                .password(PASSWORD)
+                .email(USER_EMAIL)
+                .password(USER_PASSWORD)
+                .build();
+        
+        user = User.builder()
+                .id(USER_ID)
+                .email(USER_EMAIL)
+                .password(USER_PASSWORD)
+                .name(USER_NAME)
+                .build();
+        
+        token = Token.builder()
+                .id(TOKEN_ID)
+                .user(user)
+                .token(TOKEN)
                 .build();
 
         given(service.login(any(LoginRequest.class)))
-                .willReturn(TOKEN);
+                .willReturn(token);
 
         // when
         ResultActions subject = mockMvc.perform(post("/login")

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/LoginServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/LoginServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.domain.UserRepository;
+import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.utils.TokenProvider;
 import org.junit.jupiter.api.BeforeEach;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/LoginServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/LoginServiceTest.java
@@ -1,6 +1,8 @@
 package com.codesoom.myseat.services;
 
+import com.codesoom.myseat.domain.Token;
 import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.repositories.TokenRepository;
 import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.LoginRequest;
 import com.codesoom.myseat.utils.TokenProvider;
@@ -8,36 +10,42 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 class LoginServiceTest {
     private static final String SECRET = "12345678901234567890123456789012";
-    
-    private static final String EMAIL = "test@example.com";
-    private static final String PASSWORD = "test";
-    private static final String TOKEN = "eyJhbGciOiJIUzI1NiJ9" +
-            ".eyJhdXRoIjoidGVzdEBleGFtcGxlLmNvbSJ9" +
-            ".Yoy-ZsU4g7tSfvQXEZynoHtGaSKJtrt09zNVlrR0GOE";
+
     private static final Long USER_ID = 1L;
-    private static final String NAME = "코드숨";
+    private static final String USER_NAME = "코드숨";
+    private static final String USER_EMAIL = "test@example.com";
+    private static final String USER_PASSWORD = "1234";
+    private static final Long TOKEN_ID = 2L;
+    private static final String TOKEN = "eyJhbGciOiJIUzI1NiJ9" +
+            ".eyJ1c2VySWQiOjF9" +
+            ".ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
 
     private LoginService service;
-    private final UserRepository repository = mock(UserRepository.class);
-
+    private final UserRepository userRepo = mock(UserRepository.class);
+    private final TokenRepository tokenRepo = mock(TokenRepository.class);
+    private PasswordEncoder encoder;
+            
     private LoginRequest request;
     private User user;
 
     @BeforeEach
     void setUp() {
         TokenProvider tokenProvider = new TokenProvider(SECRET);
-
-        service = new LoginService(repository, tokenProvider);
+        encoder = new BCryptPasswordEncoder();
+        service = new LoginService(userRepo, tokenProvider, tokenRepo, encoder);
     }
 
     @Nested
@@ -46,31 +54,38 @@ class LoginServiceTest {
         @BeforeEach
         void setUp() {
             request = LoginRequest.builder()
-                    .email(EMAIL)
-                    .password(PASSWORD)
+                    .email(USER_EMAIL)
+                    .password(USER_PASSWORD)
                     .build();
             
             user = User.builder()
                     .id(USER_ID)
-                    .name(NAME)
-                    .email(EMAIL)
-                    .password(PASSWORD)
+                    .name(USER_NAME)
+                    .email(USER_EMAIL)
+                    .password(encoder.encode(USER_PASSWORD))
                     .build();
 
-            given(repository.findByEmail(eq(EMAIL)))
+            given(userRepo.findByEmail(eq(USER_EMAIL)))
                     .willReturn(Optional.of(user));
+
+            given(tokenRepo.save(any(Token.class)))
+                    .will(invocation -> Token.builder()
+                            .id(TOKEN_ID)
+                            .user(user)
+                            .token(TOKEN)
+                            .build());
         }
 
         @Nested
         @DisplayName("토큰을 반환한다")
         class It_returns_token {
-            String subject() {
+            Token subject() {
                 return service.login(request);
             }
 
             @Test
             void test() {
-                assertThat(subject()).isEqualTo(TOKEN);
+                assertThat(subject().getToken()).isEqualTo(TOKEN);
             }
         }
     }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatAddServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatAddServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.dto.SeatAddRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatDetailServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatDetailServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatListServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatListServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationCancelServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationCancelServiceTest.java
@@ -1,9 +1,9 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.dto.SeatReservationCancelRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationListServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationListServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SeatReservationServiceTest.java
@@ -1,9 +1,9 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
-import com.codesoom.myseat.domain.SeatRepository;
+import com.codesoom.myseat.repositories.SeatRepository;
 import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.domain.SeatReservationRepository;
+import com.codesoom.myseat.repositories.SeatReservationRepository;
 import com.codesoom.myseat.dto.SeatReservationRequest;
 import com.codesoom.myseat.exceptions.UserAlreadyReservedSeatTodayException;
 import org.junit.jupiter.api.BeforeEach;

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.domain.UserRepository;
+import com.codesoom.myseat.repositories.UserRepository;
 import com.codesoom.myseat.dto.SignupRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/app-server/http-request/local/seat-add.http
+++ b/app-server/http-request/local/seat-add.http
@@ -1,0 +1,6 @@
+POST http://localhost:8080/seat
+Content-Type: application/json
+
+{
+  "number": 8
+}

--- a/app-server/http-request/local/signup.http
+++ b/app-server/http-request/local/signup.http
@@ -1,0 +1,8 @@
+POST http://localhost:8080/signup
+Content-Type: application/json;charset=UTF-8
+
+{
+  "name" : "한지영",
+  "email" : "jy@email.com",
+  "password" : "1234"
+}


### PR DESCRIPTION
## 작업 내용
- Token:User 1:1 양방향 매핑
- SeatReservation:User N:1 양방향 매핑
- SeatReservation:Seat 1:1 양방향 매핑
- 비밀번호 인증 시 encode의 matches 메서드를 사용하도록 수정
- 토큰 객체를 별도로 만들어서 로그인 시 토큰 객체를 반환하도록 수정

## 기타
- 현재는 단순 매핑만 한 상태로, 관련 기능들을 수정해주어야 합니다.