### PR TITLE
회원 가입 시 실제 저장되는 값과 컬럼값이 일치하지 않는 문제 해결

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/SignupController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/SignupController.java
@@ -38,6 +38,6 @@ public class SignupController {
         String name = request.getName();
         String password = request.getPassword();
 
-        service.createUser(email, name, password);
+        service.createUser(name, email, password);
     }
 }

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -1,10 +1,9 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:myseat
-    username: sa
-  h2:
-    console:
-      enabled: true
+    url: jdbc:mariadb://localhost:3306/myseattest
+    username: root
+    password: root1234
+    driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
기존에는 회원 가입 시 email 컬럼에 회원의 이름이, name 컬럼에 이메일이 저장되는 문제가 있었습니다.
이를 해결하기 위해 SignupController에서 createUser 메서드 호출 시 넣어주는 매개변수의 순서를 올바르게 수정했습니다.