### PR TITLE
서버 실행 방법을 README에 추가하라

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -17,4 +17,15 @@ $ docker run --name mariadb-container -v {볼륨 마운트 경로}:/var/lib/mysq
 *이미 컴퓨터에 MariaDB가 실행 중일 경우에는 `myseattest` 데이터베이스를 생성해 주어야 합니다.
 
 ## 서버 실행
-App 서버 실행
+
+```bash
+chmod +x gradlew # 실행 권한 업데이트
+```
+
+```bash
+docker-compose up -d # 서버 백그라운드 실행
+
+curl localhost:8080 # Hello 응답오는지 확인
+
+docker-compose down # 서버 종료
+```

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mariadb://localhost:3306/myseattest
+    url: ${url:jdbc:mariadb://localhost:3306/myseattest}
     username: root
     password: root1234
     driver-class-name: org.mariadb.jdbc.Driver

--- a/app-server/docker-compose.yml
+++ b/app-server/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  web:
+    image: gradle:6.9.2-jdk11
+    ports:
+      - "8080:8080"
+    working_dir: /app
+    volumes:
+      - .:/app
+    entrypoint: ./gradlew bootRun --args='--url="jdbc:mariadb://host.docker.internal:3306/myseattest"'


### PR DESCRIPTION
Docker로 서버를 실행할 수 있도록 docker-compose.yml을 만들었습니다.
데이터베이스가 docker에서 실행될 경우 host.docker.internal을 가리키도록 해야 합니다. 
그래서 application.yml에서 환경변수로 데이터베이스 url로 지정할 수 있도록 수정했습니다.