### PR TITLE
JSX.IntrinsicElements 에러를 없애기 위해 react와 react-dom을 최신으로 설치

### DIFF
--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@types/node": "^18.0.6",
-        "@types/react": "^18.0.15",
+        "@types/react": "^18.0.21",
         "@types/react-datepicker": "^4.4.2",
         "@types/react-dom": "^18.0.6",
         "@types/react-redux": "^7.1.24",
@@ -1078,9 +1078,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5898,9 +5898,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
+      "version": "18.0.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
+      "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.6",
-    "@types/react": "^18.0.15",
+    "@types/react": "^18.0.21",
     "@types/react-datepicker": "^4.4.2",
     "@types/react-dom": "^18.0.6",
     "@types/react-redux": "^7.1.24",


### PR DESCRIPTION
컴포넌트마다 해당 에러가 발생하여 터미널에 나온대로 
`npm install --save-dev @types/react@latest @types/react-dom@latest`
업데이트해주었습니다.