### PR TITLE
예약,회고 모달을 열고닫을수있는 상태와 액션을 만들어라

### DIFF
--- a/app-web/src/redux/reservationsSlice.test.ts
+++ b/app-web/src/redux/reservationsSlice.test.ts
@@ -1,0 +1,13 @@
+import reducer, {
+  initialState,
+  toggleReservationsModal,
+} from './reservationsSlice';
+
+describe('toggleReservationsModal', () => {
+  it('isOpenReservationsModal을 반대로 변경한다', () => {
+    const state = reducer(initialState, toggleReservationsModal());
+
+    expect(state.isOpenReservationsModal).toBe(!initialState.isOpenReservationsModal);
+  });
+});
+

--- a/app-web/src/redux/reservationsSlice.test.ts
+++ b/app-web/src/redux/reservationsSlice.test.ts
@@ -19,6 +19,3 @@ describe('toggleRetrospectModal', () => {
     expect(state.isOpenRetrospectModal).toBe(!initialState.isOpenRetrospectModal);
   });
 });
-
-
-

--- a/app-web/src/redux/reservationsSlice.test.ts
+++ b/app-web/src/redux/reservationsSlice.test.ts
@@ -1,6 +1,7 @@
 import reducer, {
   initialState,
   toggleReservationsModal,
+  toggleRetrospectModal,
 } from './reservationsSlice';
 
 describe('toggleReservationsModal', () => {
@@ -10,4 +11,14 @@ describe('toggleReservationsModal', () => {
     expect(state.isOpenReservationsModal).toBe(!initialState.isOpenReservationsModal);
   });
 });
+
+describe('toggleRetrospectModal', () => {
+  it('isOpenRetrospectModal을 반대로 변경한다', () => {
+    const state = reducer(initialState, toggleRetrospectModal());
+
+    expect(state.isOpenRetrospectModal).toBe(!initialState.isOpenRetrospectModal);
+  });
+});
+
+
 

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const initialState = {
+  isOpenReservationsModal: false,
+};
+
+const reservationsSlice = createSlice({
+  name: 'reservations',
+  initialState,
+  reducers: {
+    toggleReservationsModal: (state) => ({
+      ...state,
+      isOpenReservationsModal: !state.isOpenReservationsModal,
+    }),
+  },
+});
+
+export const { toggleReservationsModal } = reservationsSlice.actions;
+
+export default reservationsSlice.reducer;

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export const initialState = {
   isOpenReservationsModal: false,
+  isOpenRetrospectModal: false,
 };
 
 const reservationsSlice = createSlice({
@@ -12,9 +13,13 @@ const reservationsSlice = createSlice({
       ...state,
       isOpenReservationsModal: !state.isOpenReservationsModal,
     }),
+    toggleRetrospectModal: (state) => ({
+      ...state,
+      isOpenRetrospectModal: !state.isOpenRetrospectModal,
+    }),
   },
 });
 
-export const { toggleReservationsModal } = reservationsSlice.actions;
+export const { toggleReservationsModal, toggleRetrospectModal } = reservationsSlice.actions;
 
 export default reservationsSlice.reducer;


### PR DESCRIPTION
예약모달의 렌더링을 결정하는 state인 isOpenReservationsModal 을만들었습니다
회고모달의 렌더링을 결정하는 state인 isOpenRetrospectModal 을만들었습니다

예약모달을 열고닫기위해 isOpenReservationsModal을 반대로 변경시키는 toggleReservationsModal 액션을 만들었습니다
회고모달을 열고닫기위해 isOpenRetrospectModal을 반대로 변경시키는 toggleRetrospectModal  액션을 만들었습니다

