### PR TITLE
예약을 뜻하는 단어를 전부 reservation으로 통일하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationCancelController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationCancelController.java
@@ -3,7 +3,7 @@ package com.codesoom.myseat.controllers;
 import com.codesoom.myseat.domain.Seat;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.security.UserAuthentication;
-import com.codesoom.myseat.services.SeatReservationCancelService;
+import com.codesoom.myseat.services.ReservationCancelService;
 import com.codesoom.myseat.services.SeatService;
 import com.codesoom.myseat.services.UserService;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +19,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/seat-reservation")
 @CrossOrigin
 @Slf4j
-public class SeatReservationCancelController {
-    private final SeatReservationCancelService cancelService;
+public class ReservationCancelController {
+    private final ReservationCancelService cancelService;
     private final UserService userService;
     private final SeatService seatService;
 
-    public SeatReservationCancelController(
-            SeatReservationCancelService cancelService,
+    public ReservationCancelController(
+            ReservationCancelService cancelService,
             UserService userService, 
             SeatService seatService
     ) {

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationController.java
@@ -1,10 +1,10 @@
 package com.codesoom.myseat.controllers;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.dto.SeatReservationRequest;
+import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.security.UserAuthentication;
-import com.codesoom.myseat.services.SeatReservationService;
+import com.codesoom.myseat.services.ReservationService;
 import com.codesoom.myseat.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,12 +19,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/reservations")
 @CrossOrigin
 @Slf4j
-public class SeatReservationController {
-    private final SeatReservationService reservationService;
+public class ReservationController {
+    private final ReservationService reservationService;
     private final UserService userService;
 
-    public SeatReservationController(
-            SeatReservationService reservationService, 
+    public ReservationController(
+            ReservationService reservationService, 
             UserService userService
     ) {
         this.reservationService = reservationService;
@@ -41,7 +41,7 @@ public class SeatReservationController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("isAuthenticated()")
     public void reserve(
-            @RequestBody SeatReservationRequest request
+            @RequestBody ReservationRequest request
     ) {
         String email = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication()).getEmail();
         User user = userService.findUser(email);

--- a/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
@@ -11,14 +11,14 @@ import java.util.ArrayList;
 public class DbInit {
     private final UserRepository userRepo;
     private final RoleRepository roleRepo;
-    private final SeatReservationRepository reservationRepo;
+    private final ReservationRepository reservationRepo;
     private final PlanRepository planRepo;
     private final SeatRepository seatRepo;
 
     public DbInit(
             UserRepository userRepo, 
             RoleRepository roleRepo, 
-            SeatReservationRepository reservationRepo, 
+            ReservationRepository reservationRepo, 
             PlanRepository planRepo,
             SeatRepository seatRepo
     ) {
@@ -93,7 +93,7 @@ public class DbInit {
                 .content("책읽기, 코테풀기")
                 .build();
 
-        SeatReservation reservation1 = SeatReservation.builder()
+        Reservation reservation1 = Reservation.builder()
                 .date("2022-10-11")
                 .user(user1)
                 .plan(plan1)

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
@@ -29,17 +29,17 @@ public class Plan {
     private String content;
 
     @OneToOne(cascade = PERSIST)
-    @JoinColumn(name = "seatReservation_id")
-    private SeatReservation seatReservation;
+    @JoinColumn(name = "reservation_id")
+    private Reservation reservation;
 
     /**
      * 예약을 추가합니다.
      * 
-     * @param seatReservation 예약
+     * @param reservation 예약
      */
     public void addReservation(
-            SeatReservation seatReservation
+            Reservation reservation
     ) {
-        this.seatReservation = seatReservation;
+        this.reservation = reservation;
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -22,11 +22,11 @@ import static javax.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @NoArgsConstructor
 @Slf4j
-public class SeatReservation {
+public class Reservation {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name="seatReservation_id")
+    @Column(name="reservation_id")
     private Long id;
 
     private String date;
@@ -35,7 +35,7 @@ public class SeatReservation {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToOne(mappedBy = "seatReservation", cascade = PERSIST)
+    @OneToOne(mappedBy = "reservation", cascade = PERSIST)
     private Plan plan;
 
     @Convert(converter = ReservationStatusConverter.class)

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -31,7 +31,7 @@ public class User {
     private String password;
 
     @OneToOne(mappedBy = "user")
-    private SeatReservation seatReservation;
+    private Reservation reservation;
 
     @OneToOne
     @JoinColumn(name = "seat_id")
@@ -56,6 +56,6 @@ public class User {
     public void cancelReservation() {
         log.info("예약 취소");
 
-        seatReservation = null;
+        reservation = null;
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class SeatReservationRequest {
+public class ReservationRequest {
     private String date;
     
     private String content;

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
@@ -1,6 +1,6 @@
 package com.codesoom.myseat.repositories;
 
-import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,23 +8,23 @@ import java.util.List;
 /**
  * 좌석 예약 레포지토리
  */
-public interface SeatReservationRepository
-        extends JpaRepository<SeatReservation, Long> {
+public interface ReservationRepository
+        extends JpaRepository<Reservation, Long> {
     /**
      * 
      * @param s must not be {@literal null}.
      * @return
      */
-    SeatReservation save(SeatReservation s);
+    Reservation save(Reservation s);
 
     /**
      * 좌석 예약 정보를 삭제한다.
      *
      * @param s must not be {@literal null}. 삭제할 좌석 예약 정보
      */
-    void delete(SeatReservation s);
+    void delete(Reservation s);
 
-    List<SeatReservation> findAll();
+    List<Reservation> findAll();
 
     /**
      * 주어진 방문 일자와 회원 id로 예약 내역 검색에 성공하면 true, 그렇지 않으면 false를 반환합니다.

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationCancelService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationCancelService.java
@@ -2,8 +2,8 @@ package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.domain.SeatReservation;
-import com.codesoom.myseat.repositories.SeatReservationRepository;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.repositories.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -17,14 +17,14 @@ import java.util.List;
  */
 @Service
 @Slf4j
-public class SeatReservationCancelService {
+public class ReservationCancelService {
     private static final SimpleDateFormat dateFormat
             = new SimpleDateFormat("HH:mm:ss");
 
-    private final SeatReservationRepository reservationRepo;
+    private final ReservationRepository reservationRepo;
 
-    public SeatReservationCancelService(
-            SeatReservationRepository reservationRepo
+    public ReservationCancelService(
+            ReservationRepository reservationRepo
     ) {
         this.reservationRepo = reservationRepo;
     }
@@ -39,7 +39,7 @@ public class SeatReservationCancelService {
             User user,
             Seat seat
     ) {
-        SeatReservation reservation = user.getSeatReservation();
+        Reservation reservation = user.getReservation();
         user.cancelReservation();
         reservationRepo.delete(reservation);
         seat.cancelReservation();
@@ -52,8 +52,8 @@ public class SeatReservationCancelService {
     public void reset() {
         log.info("현재 시간: {}", dateFormat.format(new Date()));
         
-        List<SeatReservation> reservations = reservationRepo.findAll();
-        for(SeatReservation s : reservations) {
+        List<Reservation> reservations = reservationRepo.findAll();
+        for(Reservation s : reservations) {
             s.getUser().cancelReservation();
             Seat seat = s.getUser().getSeat();
             

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationService.java
@@ -1,11 +1,11 @@
 package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Plan;
-import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.repositories.PlanRepository;
-import com.codesoom.myseat.repositories.SeatReservationRepository;
+import com.codesoom.myseat.repositories.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -16,13 +16,13 @@ import javax.transaction.Transactional;
  */
 @Service
 @Slf4j
-public class SeatReservationService {
+public class ReservationService {
     private final PlanRepository planRepo;
-    private final SeatReservationRepository reservationRepo;
+    private final ReservationRepository reservationRepo;
 
-    public SeatReservationService(
+    public ReservationService(
             PlanRepository planRepo, 
-            SeatReservationRepository reservationRepo
+            ReservationRepository reservationRepo
     ) {
         this.planRepo = planRepo;
         this.reservationRepo = reservationRepo;
@@ -38,7 +38,7 @@ public class SeatReservationService {
      * @throws AlreadyReservedException 방문 일자에 대한 예약 내역이 이미 존재하면 던집니다.
      */
     @Transactional
-    public SeatReservation createReservation(
+    public Reservation createReservation(
             User user,
             String date,
             String content
@@ -51,7 +51,7 @@ public class SeatReservationService {
                     .content(content)
                     .build();
 
-        SeatReservation reservation = SeatReservation.builder()
+        Reservation reservation = Reservation.builder()
                 .date(date)
                 .user(user)
                 .plan(plan)

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationCancelControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationCancelControllerTest.java
@@ -3,7 +3,7 @@ package com.codesoom.myseat.controllers;
 import com.codesoom.myseat.domain.Seat;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.services.AuthenticationService;
-import com.codesoom.myseat.services.SeatReservationCancelService;
+import com.codesoom.myseat.services.ReservationCancelService;
 import com.codesoom.myseat.services.SeatService;
 import com.codesoom.myseat.services.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -25,12 +25,12 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(SeatReservationCancelController.class)
+@WebMvcTest(ReservationCancelController.class)
 @AutoConfigureRestDocs(
         uriScheme = "https", 
         uriHost = "api.codesoom-myseat.site"
 )
-class SeatReservationCancelControllerTest {
+class ReservationCancelControllerTest {
     private static final String ACCESS_TOKEN 
             = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
 
@@ -50,7 +50,7 @@ class SeatReservationCancelControllerTest {
     private AuthenticationService authService;
 
     @MockBean
-    private SeatReservationCancelService cancelService;
+    private ReservationCancelService cancelService;
 
     @MockBean
     private UserService userService;

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationControllerTest.java
@@ -1,10 +1,10 @@
 package com.codesoom.myseat.controllers;
 
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.dto.SeatReservationRequest;
+import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.services.AuthenticationService;
-import com.codesoom.myseat.services.SeatReservationService;
+import com.codesoom.myseat.services.ReservationService;
 import com.codesoom.myseat.services.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,8 +24,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
-@WebMvcTest(SeatReservationController.class)
-class SeatReservationControllerTest {
+@WebMvcTest(ReservationController.class)
+class ReservationControllerTest {
     private static final String ACCESS_TOKEN 
             = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
 
@@ -39,7 +39,7 @@ class SeatReservationControllerTest {
     private UserService userService;
     
     @MockBean
-    private SeatReservationService reservationService;
+    private ReservationService reservationService;
 
     @Test
     @DisplayName("POST /reservations 요청 시 상태코드 204를 응답한다")
@@ -57,7 +57,7 @@ class SeatReservationControllerTest {
         given(userService.findUser("soo@email.com"))
                 .willReturn(mockUser);
 
-        SeatReservationRequest request = SeatReservationRequest.builder()
+        ReservationRequest request = ReservationRequest.builder()
                 .date("2022-10-11")
                 .content("책읽기, 코테풀기")
                 .build();
@@ -89,7 +89,7 @@ class SeatReservationControllerTest {
         given(reservationService.createReservation(mockUser, "2022-10-11", "책읽기, 코테풀기"))
                 .willThrow(AlreadyReservedException.class);
 
-        SeatReservationRequest request = SeatReservationRequest.builder()
+        ReservationRequest request = ReservationRequest.builder()
                 .date("2022-10-11")
                 .content("책읽기, 코테풀기")
                 .build();

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationCancelServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationCancelServiceTest.java
@@ -2,7 +2,7 @@ package com.codesoom.myseat.services;
 
 import com.codesoom.myseat.domain.Seat;
 import com.codesoom.myseat.domain.User;
-import com.codesoom.myseat.repositories.SeatReservationRepository;
+import com.codesoom.myseat.repositories.ReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-class SeatReservationCancelServiceTest {
+class ReservationCancelServiceTest {
     private static final Long USER_ID = 1L;
     private static final String NAME = "테스터";
     private static final String EMAIL = "test@example.com";
@@ -19,14 +19,14 @@ class SeatReservationCancelServiceTest {
     private static final Long SEAT_ID = 1L;
     private static final int SEAT_NUMBER = 1;
 
-    private SeatReservationCancelService service;
+    private ReservationCancelService service;
 
-    private final SeatReservationRepository reservationRepo
-            = mock(SeatReservationRepository.class);
+    private final ReservationRepository reservationRepo
+            = mock(ReservationRepository.class);
 
     @BeforeEach
     void setUp() {
-        service = new SeatReservationCancelService(
+        service = new ReservationCancelService(
                 reservationRepo
         );
     }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationServiceTest.java
@@ -1,11 +1,11 @@
 package com.codesoom.myseat.services;
 
-import com.codesoom.myseat.domain.SeatReservation;
+import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.repositories.PlanRepository;
-import com.codesoom.myseat.repositories.SeatReservationRepository;
+import com.codesoom.myseat.repositories.ReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,11 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
-class SeatReservationServiceTest {
-    private SeatReservationService service;
+class ReservationServiceTest {
+    private ReservationService service;
 
     @Mock
-    private SeatReservationRepository reservationRepo;
+    private ReservationRepository reservationRepo;
 
     @Mock
     private PlanRepository planRepo;
@@ -29,7 +29,7 @@ class SeatReservationServiceTest {
     void setUp() {
         MockitoAnnotations.initMocks(this);
         
-        service = new SeatReservationService(planRepo, reservationRepo);
+        service = new ReservationService(planRepo, reservationRepo);
     }
     
     @Test
@@ -42,7 +42,7 @@ class SeatReservationServiceTest {
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
                 .build();
 
-        SeatReservation reservation 
+        Reservation reservation 
                 = service.createReservation(mockUser, "2022-10-11", "책읽기, 코테 풀기");
         
         assertThat(reservation.getUser().getEmail()).isEqualTo("soo@email.com");


### PR DESCRIPTION
기존에는 'SeatReservation'을 '예약'을 뜻하는 단어로 사용했었는데, 현재 예약이 좌석 예약 하나이기 때문에 굳이 Seat을 앞에 붙일 필요가 없는 것 같아서 전부 Reservation으로 수정했습니다.