### PR TITLE
login후 accessToken이 스토리지에 저장되지않던 문제를 수정하라

### DIFF
--- a/app-web/src/services/api.ts
+++ b/app-web/src/services/api.ts
@@ -48,7 +48,7 @@ export const login = async ({ email, password }: { email: string, password: stri
       email,
       password,
     }).then((res) => {
-      const accessToken = res.data.token;
+      const accessToken = res.data.accessToken;
       saveItem('accessToken', accessToken);
     }).catch((error) => {
       window.alert(error.message);


### PR DESCRIPTION
login후 토큰이 스토리지에 저장되지 않는현상이 있었습니다
코드를 확인해보니 login api 호출후 res.data.token을 저장시켜서 저장이안되었습니다
확인결과 토큰의 정보는 accessToken에 담겨있길래
지영님에게 문의후 accessToken에 있는게 맞다는 답변을 받아 수정했습니다