### PR TITLE
예약 목록 조회 API 

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
@@ -1,0 +1,52 @@
+package com.codesoom.myseat.controllers;
+
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.ReservationListResponse;
+import com.codesoom.myseat.dto.ReservationResponse;
+import com.codesoom.myseat.security.UserAuthentication;
+import com.codesoom.myseat.services.ReservationQueryService;
+import com.codesoom.myseat.services.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.stream.Collectors;
+
+/**
+ * 예약 조회 컨트롤러
+ */
+@RequestMapping("/reservations")
+@RestController
+public class ReservationQueryController {
+
+    private final UserService userService;
+    private final ReservationQueryService service;
+
+    public ReservationQueryController(UserService userService, ReservationQueryService service) {
+        this.userService = userService;
+        this.service = service;
+    }
+
+    /**
+     * 예약 목록을 조회합니다.
+     */
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    public ReservationListResponse reservations(@AuthenticationPrincipal UserAuthentication principal) {
+        String email = principal.getEmail();
+        User user = userService.findUser(email);
+
+        return new ReservationListResponse(
+                service.reservations(user.getId())
+                .stream()
+                .map(ReservationResponse::new)
+                .collect(Collectors.toList())
+        );
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListResponse.java
@@ -1,0 +1,19 @@
+package com.codesoom.myseat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 예약 목록 조회 응답 정보 */
+@NoArgsConstructor
+@Getter
+public class ReservationListResponse {
+
+    private List<ReservationResponse> reservations;
+
+    public ReservationListResponse(List<ReservationResponse> reservations) {
+        this.reservations = reservations;
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
@@ -1,0 +1,24 @@
+package com.codesoom.myseat.dto;
+
+import com.codesoom.myseat.domain.Reservation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 예약 조회 응답 정보 */
+@Getter
+@NoArgsConstructor
+public class ReservationResponse {
+
+    private Long id;
+    private String date;
+    private String plan;
+    private String status;
+
+    public ReservationResponse(Reservation reservation) {
+        this.id = reservation.getId();
+        this.date = reservation.getDate();
+        this.plan = reservation.getPlan().getContent();
+        this.status = reservation.getStatus().name();
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
@@ -34,4 +34,13 @@ public interface ReservationRepository
      * @return 주어진 방문 일자와 회원 id로 예약 내역 검색에 성공하면 true, 그렇지 않으면 false
      */
     boolean existsByDateAndUser_Id(String date, Long id);
+
+    /**
+     * 주어진 회원 정보로 예약 내역을 조회합니다.
+     *
+     * @param id 회원 아이디(PK)
+     * @return 예약 내역
+     */
+    List<Reservation> findAllByUser_Id(Long id);
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationQueryService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationQueryService.java
@@ -1,0 +1,33 @@
+package com.codesoom.myseat.services;
+
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** 예약 조회 담당 */
+@Slf4j
+@Service
+public class ReservationQueryService {
+
+    private final ReservationRepository repository;
+
+    public ReservationQueryService(ReservationRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 주어진 user id로 예약 목록을 조회합니다.
+     *
+     * @param userId 유저 아이디(PK)
+     * @return 해당 유저의 모든 예약 목록
+     */
+    @Transactional(readOnly = true)
+    public List<Reservation> reservations(Long userId) {
+        return repository.findAllByUser_Id(userId);
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationQueryControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationQueryControllerTest.java
@@ -1,0 +1,102 @@
+package com.codesoom.myseat.controllers;
+
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.services.AuthenticationService;
+import com.codesoom.myseat.services.ReservationQueryService;
+import com.codesoom.myseat.services.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ReservationQueryController.class)
+class ReservationQueryControllerTest {
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ReservationQueryService reservationQueryService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+    }
+
+    @DisplayName("요청한 유저의 모든 예약 목록을 응답한다.")
+    @Test
+    void GET_reservations_with_200_status() throws Exception {
+        String content = "코테풀기, 공부, 과제";
+        //given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn("soo@email.com");
+
+        given(userService.findUser("soo@email.com"))
+                .willReturn(mockUser);
+
+        given(reservationQueryService.reservations(1L))
+                .willReturn(List.of(
+                        Reservation.builder()
+                                .id(1L)
+                                .plan(Plan.builder().id(1L).content(content).build())
+                                .date("2022-10-13")
+                                .build()
+                ));
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/reservations")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN));
+
+        //then
+        MvcResult result = perform.andReturn();
+        assertThat(result.getResponse().getStatus()).isEqualTo(200);
+        assertThat(result.getResponse().getContentAsString()).contains(content);
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationQueryServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationQueryServiceTest.java
@@ -1,0 +1,66 @@
+package com.codesoom.myseat.services;
+
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.repositories.PlanRepository;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+
+class ReservationQueryServiceTest {
+
+    private ReservationQueryService service;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        service = new ReservationQueryService(reservationRepository);
+    }
+
+    @DisplayName("예약 목록 조회")
+    @Test
+    void will_return_reservations() {
+        //given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+        Plan plan = Plan.builder().content("공부").build();
+        Reservation reservation = Reservation.builder()
+                .user(mockUser)
+                .plan(plan)
+                .date("2022-10-12")
+                .build();
+        plan.addReservation(reservation);
+        planRepository.save(plan);
+        reservationRepository.save(reservation);
+        given(reservationRepository.findAllByUser_Id(same(1L)))
+                .willReturn(List.of(reservation));
+
+        //when
+        List<Reservation> reservations = service.reservations(mockUser.getId());
+
+        //then
+        assertThat(reservations.size()).isEqualTo(1);
+        assertThat(reservations.get(0).getUser().getId()).isEqualTo(mockUser.getId());
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationQueryServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/ReservationQueryServiceTest.java
@@ -49,9 +49,7 @@ class ReservationQueryServiceTest {
                 .plan(plan)
                 .date("2022-10-12")
                 .build();
-        plan.addReservation(reservation);
-        planRepository.save(plan);
-        reservationRepository.save(reservation);
+
         given(reservationRepository.findAllByUser_Id(same(1L)))
                 .willReturn(List.of(reservation));
 


### PR DESCRIPTION
사용자의 모든 예약 목록을 조회하는 API를 만들었습니다.

`/reservations`경로로 `GET`요청 시 인증된 사용자의 모든 예약 목록을 응답합니다.
응답 결과 예시는 아래와 같습니다.
``` json
{
  "reservations": 
  [
          { 
	          "id": 2, 
	          "date": "2022-10-10", 
	          "plan": "밥먹기, 코테풀기", 
	          "status" : "RETROSPECTIVE_COMPLETE"
          },
          { 
	          "id": 1, 
	          "date": "2022-10-09", 
	          "paln": "출근하기", 
	          "status" : "RETROSPECTIVE_WAITING"
          }
  ]
}
```