### PR TITLE
예약하기 상태를 전역으로 관리하라

### DIFF
--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import styled from '@emotion/styled';
 
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
+
+import { useAppSelector } from '../../hooks';
 
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -13,6 +15,9 @@ import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
+import { saveDate, savePlan } from '../../redux/reservationsSlice';
+import { useDispatch } from 'react-redux';
+
 
 const TextFieldWrap = styled.div({
   display: 'flex',
@@ -21,13 +26,16 @@ const TextFieldWrap = styled.div({
   padding: '1.5rem',
 });
 
+
 interface PropsType {
   open : boolean,
   onClose : React.ReactEventHandler
 }
 
-export default function ReservationDialog({ open, onClose } : PropsType) {
-  const [value, setValue] = React.useState<Dayjs | null>(dayjs().add(1, 'day'));
+export default function ReservationDialog({ open, onClose }: PropsType) {
+  const dispatch = useDispatch();
+
+  const { date, plan } = useAppSelector(store => store.reservations);
 
   return (
     <Dialog
@@ -41,16 +49,22 @@ export default function ReservationDialog({ open, onClose } : PropsType) {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker
             label="방문일자"
-            value={value}
-            onChange={(newValue) => {
-              setValue(newValue);
+            value={date}
+            onChange={(value): any => {
+              dispatch(saveDate(dayjs(value).format('YYYY-MM-DD')));
             }}
-            renderInput={(params) => <TextField {...params} />}
+            renderInput={(params) => {
+              return (<TextField {...params} />);
+            }}
           />
         </LocalizationProvider>
 
         <TextField
           label="계획"
+          value={plan}
+          onChange={(e): any => {
+            dispatch(savePlan(e.target.value));
+          }}
           variant="outlined"
           multiline
           rows={3}

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -49,9 +49,11 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker
             label="방문일자"
-            value={date}
-            onChange={(value): any => {
-              dispatch(saveDate(dayjs(value).format('YYYY-MM-DD')));
+            value={date === null ? null : dayjs(date)}
+            onChange={(value) => {
+              dispatch(
+                saveDate(value === null ? null : dayjs(value).format('YYYY-MM-DD')),
+              );
             }}
             renderInput={(params) => {
               return (<TextField {...params} />);

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 
 import styled from '@emotion/styled';
 
 import dayjs from 'dayjs';
-
-import { useAppSelector } from '../../hooks';
 
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -15,8 +14,9 @@ import TextField from '@mui/material/TextField';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
+
+import { useAppSelector } from '../../hooks';
 import { saveDate, savePlan } from '../../redux/reservationsSlice';
-import { useDispatch } from 'react-redux';
 
 
 const TextFieldWrap = styled.div({

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -64,7 +64,7 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
         <TextField
           label="계획"
           value={plan}
-          onChange={(e): any => {
+          onChange={(e) => {
             dispatch(savePlan(e.target.value));
           }}
           variant="outlined"

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -18,14 +18,12 @@ import DialogTitle from '@mui/material/DialogTitle';
 import { useAppSelector } from '../../hooks';
 import { saveDate, savePlan } from '../../redux/reservationsSlice';
 
-
 const TextFieldWrap = styled.div({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-around',
   padding: '1.5rem',
 });
-
 
 interface PropsType {
   open : boolean,
@@ -36,6 +34,12 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
   const dispatch = useDispatch();
 
   const { date, plan } = useAppSelector(store => store.reservations);
+
+  const handleChange = (value: dayjs.Dayjs | null) => {
+    dispatch(
+      saveDate(value === null ? null : dayjs(value).format('YYYY-MM-DD')),
+    );
+  };
 
   return (
     <Dialog
@@ -50,11 +54,7 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
           <DatePicker
             label="방문일자"
             value={date === null ? null : dayjs(date)}
-            onChange={(value) => {
-              dispatch(
-                saveDate(value === null ? null : dayjs(value).format('YYYY-MM-DD')),
-              );
-            }}
+            onChange={(value) => handleChange(value)}
             renderInput={(params) => {
               return (<TextField {...params} />);
             }}

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -1,11 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
-import dayjs from 'dayjs';
+
 
 export const initialState = {
   isOpenReservationsModal: false,
   isOpenRetrospectModal: false,
 
-  date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
+  date: null,
   plan: '',
 };
 

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -1,8 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
+import dayjs from 'dayjs';
 
 export const initialState = {
   isOpenReservationsModal: false,
   isOpenRetrospectModal: false,
+
+  date: dayjs().add(1, 'day').format('YYYY-MM-DD'),
+  plan: '',
 };
 
 const reservationsSlice = createSlice({
@@ -17,9 +21,25 @@ const reservationsSlice = createSlice({
       ...state,
       isOpenRetrospectModal: !state.isOpenRetrospectModal,
     }),
+
+    saveDate: (state, { payload }) => {
+      console.log(payload);
+      return ({
+        ...state,
+        date: payload,
+      });
+    },
+    savePlan: (state, { payload }) => ({
+      ...state,
+      plan: payload,
+    }),
   },
 });
 
-export const { toggleReservationsModal, toggleRetrospectModal } = reservationsSlice.actions;
+export const {
+  toggleReservationsModal,
+  toggleRetrospectModal,
+  saveDate,
+  savePlan } = reservationsSlice.actions;
 
 export default reservationsSlice.reducer;

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -23,7 +23,6 @@ const reservationsSlice = createSlice({
     }),
 
     saveDate: (state, { payload }) => {
-      console.log(payload);
       return ({
         ...state,
         date: payload,

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -40,6 +40,7 @@ export const {
   toggleReservationsModal,
   toggleRetrospectModal,
   saveDate,
-  savePlan } = reservationsSlice.actions;
+  savePlan,
+} = reservationsSlice.actions;
 
 export default reservationsSlice.reducer;

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -1,11 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
-import dayjs from 'dayjs';
 
 interface ReservationState {
   isOpenReservationsModal: boolean,
   isOpenRetrospectModal: boolean,
 
-  date: dayjs.Dayjs | null,
+  date: string | null,
   plan: string,
 }
 

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -1,7 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit';
+import dayjs from 'dayjs';
 
+interface ReservationState {
+  isOpenReservationsModal: boolean,
+  isOpenRetrospectModal: boolean,
 
-export const initialState = {
+  date: dayjs.Dayjs | null,
+  plan: string,
+}
+
+export const initialState: ReservationState = {
   isOpenReservationsModal: false,
   isOpenRetrospectModal: false,
 

--- a/app-web/src/store.ts
+++ b/app-web/src/store.ts
@@ -7,7 +7,6 @@ import reservationsSlice from './redux/reservationsSlice';
 
 export const store = configureStore({
   reducer: {
-    // TODO: 추후 reservation 미팅후 제거결정
     reservation: reservationReducer,
     auth: authSlice,
     retrospections: retrospectionsReducer,


### PR DESCRIPTION
예약하기 위해 입력하는 날짜와 계획을 저장하는 리덕스 액션을 작성했습니다.
기존 컴포넌트 내에서 상태를 관리하던 것을 리덕스를 사용해 전역으로 관리하도록 변경했습니다.
만들어둔 액션을 사용하기 위해 스토어에 리듀서를 불러왔습니다. 