### PR TITLE
email이 아니라 id로 Claim을 만들어라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/LoginController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/LoginController.java
@@ -42,7 +42,7 @@ public class LoginController {
         String email = request.getEmail();
         String password = request.getPassword();
 
-        User user = userService.findUser(email);
+        User user = userService.findByEmail(email);
 
         String accessToken = authService.login(user, password);
         log.info("accessToken: " + accessToken);

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationCancelController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationCancelController.java
@@ -9,7 +9,7 @@ import com.codesoom.myseat.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -43,10 +43,10 @@ public class ReservationCancelController {
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("isAuthenticated()")
     public void cancelReservation(
+            @AuthenticationPrincipal UserAuthentication principal,
             @PathVariable int number
     ) {
-        String email = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication()).getEmail();
-        User user = userService.findUser(email);
+        User user = userService.findById(principal.getId());
         Seat seat = seatService.findSeat(number);
 
         cancelService.cancelReservation(user, seat);

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationController.java
@@ -9,7 +9,7 @@ import com.codesoom.myseat.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -41,10 +41,10 @@ public class ReservationController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("isAuthenticated()")
     public void reserve(
+            @AuthenticationPrincipal UserAuthentication principal,
             @RequestBody ReservationRequest request
     ) {
-        String email = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication()).getEmail();
-        User user = userService.findUser(email);
+        User user = userService.findById(principal.getId());
 
         String date = request.getDate();
         String content = request.getContent();

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
@@ -38,8 +38,7 @@ public class ReservationQueryController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
     public ReservationListResponse reservations(@AuthenticationPrincipal UserAuthentication principal) {
-        String email = principal.getEmail();
-        User user = userService.findUser(email);
+        User user = userService.findById(principal.getId());
 
         return new ReservationListResponse(
                 service.reservations(user.getId())

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/SeatDetailController.java
@@ -3,14 +3,13 @@ package com.codesoom.myseat.controllers;
 import com.codesoom.myseat.domain.Seat;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.SeatDetailResponse;
-import com.codesoom.myseat.exceptions.AuthenticationFailureException;
 import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.SeatService;
 import com.codesoom.myseat.services.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -42,17 +41,12 @@ public class SeatDetailController {
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("isAuthenticated()")
     public SeatDetailResponse seatDetail(
+            @AuthenticationPrincipal UserAuthentication principal,
             @PathVariable int number
     ) {
         log.info("number: " + number);
 
-        String email = ((UserAuthentication) SecurityContextHolder.getContext().getAuthentication()).getEmail();
-        if(email == null) {
-            throw new AuthenticationFailureException();
-        }
-        log.info("email: " + email);
-
-        User user = userService.findUser(email);
+        User user = userService.findById(principal.getId());
 
         return toResponse(user, seatService.findSeat(number));
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
@@ -72,7 +72,7 @@ public class DbInit {
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
                 .build();
         Role role1 = Role.builder()
-                .email("soo@email.com")
+                .userId(1L)
                 .roleName("USER")
                 .build();
         User user2 = User.builder()
@@ -81,7 +81,7 @@ public class DbInit {
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
                 .build();
         Role role2 = Role.builder()
-                .email("young@email.com")
+                .userId(2L)
                 .roleName("USER")
                 .build();
         userRepo.save(user1);

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Role.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Role.java
@@ -18,7 +18,7 @@ public class Role {
     @GeneratedValue
     private Long id;
 
-    private String email;
+    private Long userId;
 
     @Getter
     private String roleName;

--- a/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
@@ -43,13 +43,13 @@ public class AuthenticationFilter extends BasicAuthenticationFilter {
             String accessToken = authHeader.substring("Bearer ".length());
             log.info("accessToken: " + accessToken);
 
-            String email = authService.parseToken(accessToken);
-            log.info("email: " + email);
+            Long id = authService.parseToken(accessToken);
+            log.info("id: " + id);
 
-            List<Role> roles = authService.roles(email);
+            List<Role> roles = authService.roles(id);
             log.info("roles: " + roles);
 
-            Authentication authentication = new UserAuthentication(email, roles);
+            Authentication authentication = new UserAuthentication(id, roles);
             log.info("authentication: " + authentication.getAuthorities());
 
             SecurityContext context = SecurityContextHolder.getContext();

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/RoleRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/RoleRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface RoleRepository 
         extends JpaRepository<Role, Long> {
-    List<Role> findAllByEmail(String email);
+    List<Role> findAllByUserId(Long id);
 
     Role save(Role role);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
@@ -20,10 +20,18 @@ public interface UserRepository
     User save(User user);
 
     /**
-     * 이메일로 회원 엔티티를 검색한다.
+     * 주어진 id로 회원을 조회하고, 조회된 회원 엔티티를 반환합니다.
+     * 
+     * @param id 회원 id
+     * @return 조회된 회원 엔티티
+     */
+    Optional<User> findById(Long id);
+
+    /**
+     * 주어진 이메일로 회원을 조회하고, 조회된 회원 엔티티를 반환합니다.
      * 
      * @param email 이메일
-     * @return 회원 엔티티
+     * @return 조회된 회원 엔티티
      */
     Optional<User> findByEmail(String email);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/security/UserAuthentication.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/security/UserAuthentication.java
@@ -10,18 +10,18 @@ import java.util.stream.Collectors;
 
 public class UserAuthentication 
         extends AbstractAuthenticationToken {
-    private final String email;
+    private final Long id;
 
     public UserAuthentication(
-            String email,
+            Long id,
             List<Role> roles
     ) {
         super(authorities(roles));
-        this.email = email;
+        this.id = id;
     }
 
-    public String getEmail() {
-        return email;
+    public Long getId() {
+        return id;
     }
 
     @Override
@@ -31,7 +31,7 @@ public class UserAuthentication
 
     @Override
     public Object getPrincipal() {
-        return email;
+        return id;
     }
 
     @Override
@@ -41,7 +41,7 @@ public class UserAuthentication
 
     @Override
     public String toString() {
-        return "Authentication: " + email;
+        return "Authentication: " + id;
     }
 
     private static List<GrantedAuthority> authorities(

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/AuthenticationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/AuthenticationService.java
@@ -46,16 +46,16 @@ public class AuthenticationService {
             throw new AuthenticationFailureException();
         }
 
-        return jwtUtil.makeAccessToken(user.getEmail());
+        return jwtUtil.makeAccessToken(user.getId());
     }
 
     /**
      * 토큰을 파싱한다.
      * 
      * @param accessToken 토큰
-     * @return 이메일
+     * @return 회원 id
      */
-    public String parseToken(
+    public Long parseToken(
             String accessToken
     ) {
         return jwtUtil.parseAccessToken(accessToken);
@@ -64,12 +64,12 @@ public class AuthenticationService {
     /**
      * 권한 목록을 반환한다.
      * 
-     * @param email 이메일
+     * @param id 회원 id
      * @return 권한 목록
      */
     public List<Role> roles(
-            String email
+            Long id
     ) {
-        return roleRepo.findAllByEmail(email);
+        return roleRepo.findAllByUserId(id);
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/SignupService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/SignupService.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+
 /**
  * 회원 가입 서비스
  */
@@ -36,23 +38,25 @@ public class SignupService {
      * @param password 비밀번호
      * @return 회원
      */
+    @Transactional
     public User createUser(
             String name,
             String email,
             String password
     ) {
-        Role role = Role.builder()
-                .email(email)
-                .roleName("USER")
-                .build();
-        
-        roleRepo.save(role);
-
-        return userRepo.save(User.builder()
+        User user = userRepo.save(User.builder()
                 .name(name)
                 .email(email)
                 .password(passwordEncoder.encode(password))
-                .build()
-        );
+                .build());
+
+        Role role = Role.builder()
+                .userId(user.getId())
+                .roleName("USER")
+                .build();
+
+        roleRepo.save(role);
+        
+        return user;
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/UserService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/UserService.java
@@ -21,12 +21,27 @@ public class UserService {
     }
 
     /**
-     * 이메일로 회원을 검색한다.
+     * id로 회원 조회에 성공하면 회원을 반환합니다.
      * 
-     * @param email
-     * @return
+     * @param id 아이디
+     * @return 조회된 회원
+     * @throws UserNotFoundException 회원 조회에 실패하면 던집니다.
      */
-    public User findUser(
+    public User findById(
+            Long id
+    ) {
+        return userRepo.findById(id)
+                .orElseThrow(() -> new UserNotFoundException());
+    }
+
+    /**
+     * 이메일로 회원 조회에 성공하면 회원을 반환합니다.
+     * 
+     * @param email 이메일
+     * @return 조회된 회원
+     * @throws UserNotFoundException 회원 조회에 실패하면 던집니다.
+     */
+    public User findByEmail(
             String email
     ) {
         return userRepo.findByEmail(email)

--- a/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
@@ -26,10 +26,10 @@ public class JwtUtil {
     /**
      * 생성된 토큰을 반환한다.
      * 
-     * @param email 토큰을 부여할 회원 이메일
+     * @param id 토큰을 부여할 회원의 id
      * @return 토큰 
      */
-    public String makeAccessToken(String email) {
+    public String makeAccessToken(Long id) {
         Date now = new Date();
 
         return Jwts.builder()
@@ -37,7 +37,7 @@ public class JwtUtil {
                 .setIssuer("fresh")
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + Duration.ofMinutes(30).toMillis()))
-                .claim("email", email)
+                .claim("id", id)
                 .signWith(key)
                 .compact();
     }
@@ -48,7 +48,7 @@ public class JwtUtil {
      * @param accessToken
      * @return 이메일
      */
-    public String parseAccessToken(String accessToken) {
+    public Long parseAccessToken(String accessToken) {
         log.info("accessToken: " + accessToken);
 
         Claims claims = Jwts.parserBuilder()
@@ -57,12 +57,12 @@ public class JwtUtil {
                 .parseClaimsJws(accessToken)
                 .getBody();
 
-        String email = claims.get("email", String.class);
-        log.info("email: " + email);
-        if(email == null) {
+        Long id = claims.get("id", Long.class);
+        log.info("id: " + id);
+        if(id == null) {
             log.info("@@@@@@@@@@@없어");
         }
 
-        return email;
+        return id;
     }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/LoginControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/LoginControllerTest.java
@@ -68,7 +68,7 @@ class LoginControllerTest {
                 .password(ENCODED_PASSWORD)
                 .build();
 
-        given(userService.findUser(EMAIL))
+        given(userService.findById(ID))
                 .willReturn(user);
 
         given(authService.login(user, PASSWORD))

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationCancelControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationCancelControllerTest.java
@@ -78,9 +78,9 @@ class ReservationCancelControllerTest {
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(EMAIL);
+                .willReturn(1L);
 
-        given(userService.findUser(EMAIL))
+        given(userService.findById(1L))
                 .willReturn(user);
 
         given(seatService.findSeat(NUMBER))

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationControllerTest.java
@@ -52,9 +52,9 @@ class ReservationControllerTest {
                 .build();
         
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn("soo@email.com");
+                .willReturn(1L);
         
-        given(userService.findUser("soo@email.com"))
+        given(userService.findById(1L))
                 .willReturn(mockUser);
 
         ReservationRequest request = ReservationRequest.builder()
@@ -81,9 +81,9 @@ class ReservationControllerTest {
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn("soo@email.com");
+                .willReturn(1L);
 
-        given(userService.findUser("soo@email.com"))
+        given(userService.findById(1L))
                 .willReturn(mockUser);
 
         given(reservationService.createReservation(mockUser, "2022-10-11", "책읽기, 코테풀기"))

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationQueryControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/ReservationQueryControllerTest.java
@@ -75,9 +75,9 @@ class ReservationQueryControllerTest {
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn("soo@email.com");
+                .willReturn(1L);
 
-        given(userService.findUser("soo@email.com"))
+        given(userService.findById(1L))
                 .willReturn(mockUser);
 
         given(reservationQueryService.reservations(1L))

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatAddControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatAddControllerTest.java
@@ -65,7 +65,7 @@ class SeatAddControllerTest {
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(EMAIL);
+                .willReturn(1L);
         
         given(seatAddService.createSeat(NUMBER))
                 .will(invocation -> Seat.builder()

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/SeatDetailControllerTest.java
@@ -85,9 +85,9 @@ class SeatDetailControllerTest {
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(EMAIL);
+                .willReturn(1L);
 
-        given(userService.findUser(EMAIL))
+        given(userService.findById(1L))
                 .willReturn(user);
 
         given(seatService.findSeat(NUMBER))

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/AuthenticationServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/AuthenticationServiceTest.java
@@ -53,7 +53,7 @@ class AuthenticationServiceTest {
     @DisplayName("로그인 성공")
     void login_success() {
         // given
-        given(jwtUtil.makeAccessToken(EMAIL))
+        given(jwtUtil.makeAccessToken(1L))
                 .willReturn(ACCESS_TOKEN);
 
         User user = User.builder()

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/SignupServiceTest.java
@@ -49,7 +49,7 @@ class SignupServiceTest {
         // given
         given(roleRepo.save(any(Role.class)))
                 .will(invocation -> Role.builder()
-                        .email(EMAIL)
+                        .userId(1L)
                         .roleName("USER")
                         .build());
 


### PR DESCRIPTION
JWT Claim에 사용자의 email만 저장하고 있었습니다.
그래서 사용자의 id 조회할 때 email로 조회해서 얻고 있었습니다.
그리고 사용자의 email은 변경될 수 있으므로 사용자의 id를 저장하는게 더 좋습니다.
따라서 JWT Claim에 사용자의 id를 저장하도록 변경했습니다.
