### PR TITLE
파일의 연관성을 위한 회고모달의 렌더링을 결정하는 state,action을 회고관련 redux로 옮겨라

### DIFF
--- a/app-web/src/redux/reservationsSlice.test.ts
+++ b/app-web/src/redux/reservationsSlice.test.ts
@@ -1,7 +1,6 @@
 import reducer, {
   initialState,
   toggleReservationsModal,
-  toggleRetrospectModal,
 } from './reservationsSlice';
 
 describe('toggleReservationsModal', () => {
@@ -9,13 +8,5 @@ describe('toggleReservationsModal', () => {
     const state = reducer(initialState, toggleReservationsModal());
 
     expect(state.isOpenReservationsModal).toBe(!initialState.isOpenReservationsModal);
-  });
-});
-
-describe('toggleRetrospectModal', () => {
-  it('isOpenRetrospectModal을 반대로 변경한다', () => {
-    const state = reducer(initialState, toggleRetrospectModal());
-
-    expect(state.isOpenRetrospectModal).toBe(!initialState.isOpenRetrospectModal);
   });
 });

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -2,7 +2,6 @@ import { createSlice } from '@reduxjs/toolkit';
 
 interface ReservationState {
   isOpenReservationsModal: boolean,
-  isOpenRetrospectModal: boolean,
 
   date: string | null,
   plan: string,
@@ -10,7 +9,6 @@ interface ReservationState {
 
 export const initialState: ReservationState = {
   isOpenReservationsModal: false,
-  isOpenRetrospectModal: false,
 
   date: null,
   plan: '',
@@ -24,11 +22,6 @@ const reservationsSlice = createSlice({
       ...state,
       isOpenReservationsModal: !state.isOpenReservationsModal,
     }),
-    toggleRetrospectModal: (state) => ({
-      ...state,
-      isOpenRetrospectModal: !state.isOpenRetrospectModal,
-    }),
-
     saveDate: (state, { payload }) => {
       return ({
         ...state,
@@ -44,7 +37,6 @@ const reservationsSlice = createSlice({
 
 export const {
   toggleReservationsModal,
-  toggleRetrospectModal,
   saveDate,
   savePlan,
 } = reservationsSlice.actions;

--- a/app-web/src/redux/retrospectionSlice.tsx
+++ b/app-web/src/redux/retrospectionSlice.tsx
@@ -1,10 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 interface RetrospectionState {
+  isOpenRetrospectModal:boolean,
   retrospections: string,
 }
 
 const initialState: RetrospectionState = {
+  isOpenRetrospectModal: false,
   retrospections: '',
 };
 
@@ -12,6 +14,10 @@ const { reducer, actions } = createSlice({
   name: 'retrospections',
   initialState,
   reducers: {
+    toggleRetrospectModal: (state) => ({
+      ...state,
+      isOpenRetrospectModal: !state.isOpenRetrospectModal,
+    }),
     writeRetrospection: (state, { payload }) => {
       return {
         ...state,
@@ -22,6 +28,7 @@ const { reducer, actions } = createSlice({
 });
 
 export const {
+  toggleRetrospectModal,
   writeRetrospection,
 } = actions;
 


### PR DESCRIPTION
기존에 예약 redux파일에 회고모달 렌더링여부를 결정하는 state와 action이 있었습니다
회고모달렌더링 여부확인은 회고관련된 파일로 옮기는것이 맞는거같아 수정했습니다

회고모달의 렌더링을 결정하는 isOpenRetrospectModal 상태를 retrospectionSlice로 옮겼습니다
isOpenRetrospectModal을 반대로 변경하는 action을 retrospectionSlice로 옮겼습니다