### PR TITLE
회고를작성할수게끔 모달을 열고닫을수있게 하라

### DIFF
--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -25,12 +25,12 @@ const TextFieldWrap = styled.div({
   padding: '1.5rem',
 });
 
-interface PropsType {
+interface Props {
   open : boolean,
   onClose : React.ReactEventHandler
 }
 
-export default function ReservationDialog({ open, onClose }: PropsType) {
+export default function ReservationDialog({ open, onClose }: Props) {
   const dispatch = useDispatch();
 
   const { date, plan } = useAppSelector(store => store.reservations);

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -16,6 +16,9 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogTitle from '@mui/material/DialogTitle';
 
 import { useAppSelector } from '../../hooks';
+
+import { get } from '../../utils';
+
 import { saveDate, savePlan } from '../../redux/reservationsSlice';
 
 const TextFieldWrap = styled.div({
@@ -33,7 +36,7 @@ interface Props {
 export default function ReservationDialog({ open, onClose }: Props) {
   const dispatch = useDispatch();
 
-  const { date, plan } = useAppSelector(store => store.reservations);
+  const { date, plan } = useAppSelector(get('reservations'));
 
   const handleChange = (value: dayjs.Dayjs | null) => {
     dispatch(

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -127,9 +127,10 @@ const rows = [
 
 interface PropsType {
   onOpenReservationModal : React.ReactEventHandler,
+  onOpenRetrospectModal : React.ReactEventHandler
 }
 
-export default function ReservationsTable({ onOpenReservationModal }:PropsType) {
+export default function ReservationsTable({ onOpenReservationModal, onOpenRetrospectModal }:PropsType) {
   const [page, setPage] = React.useState(0);
 
   const rowsPerPage = 10;
@@ -162,7 +163,7 @@ export default function ReservationsTable({ onOpenReservationModal }:PropsType) 
               <TableCell>{date}</TableCell>
               <TableCell align="left">{plan}</TableCell>
               <TableCell align="right">
-                <Button>
+                <Button onClick={onOpenRetrospectModal}>
                   {status === 'RETROSPECTIVE_COMPLETE' ? '회고제출' : '제출됨'}
                 </Button>
               </TableCell>

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -125,12 +125,12 @@ const rows = [
   createData(23, '2022-10-23', 'javascript 공부', Status.RETROSPECTIVE_COMPLETE),
 ];
 
-interface PropsType {
+interface Props {
   onOpenReservationModal : React.ReactEventHandler,
   onOpenRetrospectModal : React.ReactEventHandler
 }
 
-export default function ReservationsTable({ onOpenReservationModal, onOpenRetrospectModal }:PropsType) {
+export default function ReservationsTable({ onOpenReservationModal, onOpenRetrospectModal }: Props) {
   const [page, setPage] = React.useState(0);
 
   const rowsPerPage = 10;

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -8,9 +8,12 @@ import { useAppDispatch, useAppSelector } from '../hooks';
 import { get } from '../utils';
 
 import { toggleReservationsModal } from '../redux/reservationsSlice';
+import { toggleRetrospectModal } from '../redux/retrospectionSlice';
 
 import ReservationDialog from '../components/reservation/ReservationDialog';
 import ReservationsTable from '../components/reservations/ReservationsTable';
+
+import RetrospectionModal from './Retrospection';
 
 const Container = styled.div({
   display: 'flex',
@@ -43,9 +46,14 @@ export default function Reservations() {
   const dispatch = useAppDispatch();
 
   const { isOpenReservationsModal } = useAppSelector(get('reservations'));
+  const { isOpenRetrospectModal } = useAppSelector(get('retrospections'));
 
   const onClicktoggleReservationsModal = () => {
     dispatch(toggleReservationsModal());
+  };
+
+  const onClicktoggleRetrospectModal = () => {
+    dispatch(toggleRetrospectModal());
   };
 
   return (
@@ -53,6 +61,10 @@ export default function Reservations() {
       <ReservationDialog
         open={isOpenReservationsModal}
         onClose={onClicktoggleReservationsModal}
+      />
+      <RetrospectionModal
+        open={isOpenRetrospectModal}
+        onClose={onClicktoggleRetrospectModal}
       />
 
       <Wrap>
@@ -66,7 +78,10 @@ export default function Reservations() {
           </Button>
         </Header>
 
-        <ReservationsTable onOpenReservationModal={onClicktoggleReservationsModal} />
+        <ReservationsTable
+          onOpenReservationModal={onClicktoggleReservationsModal}
+          onOpenRetrospectModal={onClicktoggleRetrospectModal}
+        />
       </Wrap>
     </Container>
   );

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -25,12 +25,12 @@ const ButtonWrap = styled.div({
   },
 });
 
-interface PropsType {
+interface Props {
   open : boolean,
   onClose : React.ReactEventHandler
 }
 
-const RetrospectionModal: React.FC<PropsType> = ({ open, onClose } : PropsType) => {
+const RetrospectionModal: React.FC<Props> = ({ open, onClose } : Props) => {
   const dispatch = useDispatch();
 
   const { retrospections } = useAppSelector((state) => state.retrospections);

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -25,8 +25,14 @@ const ButtonWrap = styled.div({
   },
 });
 
-const RetrospectionModal: React.FC = () => {
+interface PropsType {
+  open : boolean,
+  onClose : React.ReactEventHandler
+}
+
+const RetrospectionModal: React.FC<PropsType> = ({ open, onClose } : PropsType) => {
   const dispatch = useDispatch();
+
   const { retrospections } = useAppSelector((state) => state.retrospections);
 
   const characterMinimum = 100;
@@ -40,7 +46,8 @@ const RetrospectionModal: React.FC = () => {
 
   return (
     <Dialog
-      open
+      open={open}
+      onClose={onClose}
     >
       <Wrap>
         <IconButton
@@ -51,7 +58,9 @@ const RetrospectionModal: React.FC = () => {
           }}
           color='primary'
           aria-label='close dialog'
-          component='label'>
+          component='label'
+          onClick={onClose}
+        >
           <CloseIcon />
         </IconButton>
         <TextField
@@ -68,7 +77,7 @@ const RetrospectionModal: React.FC = () => {
           rows={3}
         />
         <ButtonWrap>
-          <Button variant='outlined' size='small'>
+          <Button onClick={onClose} variant='outlined' size='small'>
             취소
           </Button>
           <Button

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -58,7 +58,7 @@ const RetrospectionModal: React.FC<Props> = ({ open, onClose } : Props) => {
           }}
           color='primary'
           aria-label='close dialog'
-          component='label'
+          component="label"
           onClick={onClose}
         >
           <CloseIcon />


### PR DESCRIPTION
퍼블리싱 되어있는 회고모달과 회고모달의 state, action을 연결하여
예약내역페이지에서 회고제출을 클릭하면 회고모달을 열수있게했습니다
회고모달의 백그라운드를 클릭시 모달이 닫히게했습니다
회고모달의 취소 , x 버튼 클릭시 모달이 닫히게했습니다

![Oct-13-2022 20-10-08](https://user-images.githubusercontent.com/57708817/195581518-eaa6adc2-6b71-41e9-a71a-1d9c04c799f1.gif)
