### PR TITLE
유효하지 않은 토큰이 주어질 경우 던질 예외를 추가하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/InvalidTokenException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/InvalidTokenException.java
@@ -1,0 +1,16 @@
+package com.codesoom.myseat.exceptions;
+
+/** 유효하지 않은 토큰일 경우 던집니다. */
+public class InvalidTokenException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "유효하지 않은 토큰입니다.";
+
+    public InvalidTokenException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
토큰 유효성 검사를 실패할 경우 던질 예외를 추가합니다.

해당 예외는 올바르지 않은 토큰이 주어질 경우, 토큰 검증에 실패할 경우, 토큰의 스킴이 `Bearer `가 아닐 경우 등에 사용됩니다.