### PR TITLE
JWT 토큰 검증 실패시 401 UnAuthorized를 반환하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.codesoom.myseat.config;
 
+import com.codesoom.myseat.filters.AuthenticationErrorFilter;
 import com.codesoom.myseat.filters.AuthenticationFilter;
 import com.codesoom.myseat.services.AuthenticationService;
 import org.springframework.context.annotation.Configuration;
@@ -30,9 +31,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(
             HttpSecurity http
     ) throws Exception {
-        Filter authFilter 
-                = new AuthenticationFilter(authenticationManager(), authService);
-
         http
                 .cors()
                 .and()
@@ -51,12 +49,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/h2-console/**", "/", "/docs/**", "/signup", "/login", "/seats").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .addFilter(authFilter)
+                .addFilter(authenticationFilter())
+                .addFilterBefore(authenticationErrorFilter(), AuthenticationFilter.class)
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .exceptionHandling()
                 .authenticationEntryPoint(
-                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));;
+                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
     }
+
+    private Filter authenticationFilter() throws Exception {
+        return new AuthenticationFilter(authenticationManager(), authService);
+    }
+
+    private Filter authenticationErrorFilter() {
+        return new AuthenticationErrorFilter();
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationErrorFilter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationErrorFilter.java
@@ -1,0 +1,30 @@
+package com.codesoom.myseat.filters;
+
+import com.codesoom.myseat.exceptions.InvalidTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/** 토큰 검증 필터에서 발생한 예외 처리 담당 */
+@Slf4j
+public class AuthenticationErrorFilter extends HttpFilter {
+
+    @Override
+    protected void doFilter(HttpServletRequest request,
+                            HttpServletResponse response,
+                            FilterChain chain) throws IOException, ServletException {
+        try {
+            chain.doFilter(request, response);
+        } catch (InvalidTokenException e) {
+            log.error(e.getMessage());
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), e.getMessage());
+        }
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
@@ -1,9 +1,11 @@
 package com.codesoom.myseat.filters;
 
 import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.exceptions.InvalidTokenException;
 import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.AuthenticationService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -20,6 +22,9 @@ import java.util.List;
 
 @Slf4j
 public class AuthenticationFilter extends BasicAuthenticationFilter {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
     private final AuthenticationService authService;
 
     public AuthenticationFilter(
@@ -30,18 +35,18 @@ public class AuthenticationFilter extends BasicAuthenticationFilter {
         this.authService = authService;
     }
 
+    /**
+     * http authorization 헤더의 토큰이 유효하면 SecurityContext에 인증 정보를 등록합니다.
+     */
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, 
             HttpServletResponse response, 
             FilterChain filterChain
     ) throws ServletException, IOException {
-        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        log.info("header: " + authHeader);
 
-        if(authHeader != null) {
-            String accessToken = authHeader.substring("Bearer ".length());
-            log.info("accessToken: " + accessToken);
+        if (request.getHeader(HttpHeaders.AUTHORIZATION) != null) {
+            String accessToken = getAccessToken(request);
 
             Long id = authService.parseToken(accessToken);
             log.info("id: " + id);
@@ -59,4 +64,24 @@ public class AuthenticationFilter extends BasicAuthenticationFilter {
 
         filterChain.doFilter(request, response);
     }
+
+    /**
+     * 요청 헤더에 담긴 토큰을 반환합니다.
+     *
+     * @param request http 요청
+     * @return accessToken
+     * @throws InvalidTokenException 유효하지 않은 토큰일 경우 던짐
+     */
+    private String getAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("header: " + token);
+        if (Strings.isBlank(token)) {
+            throw new InvalidTokenException("토큰을 입력하세요.");
+        }
+        if (!token.startsWith(TOKEN_PREFIX)) {
+            throw new InvalidTokenException("지원하지 않는 토큰 타입입니다.");
+        }
+        return token.substring(TOKEN_PREFIX.length());
+    }
+
 }


### PR DESCRIPTION
`AuthenticationErrorFilter`를 추가해서 `AuthenticationFilter`에서 발생하는 토큰 유효성 검증 예외를 처리했습니다.

기존에는 `AuthenticationFilter`에서 토큰 검증이 실패해도 예외 처리가 없었습니다.
에러 필터를 추가하여 발생하는 예외를 처리하고 401 unauthorized 응답을 하도록 수정했습니다.