### PR TITLE
토큰 파싱에 실패했을 경우 예외를 던져라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
@@ -1,7 +1,9 @@
 package com.codesoom.myseat.utils;
 
+import com.codesoom.myseat.exceptions.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -51,18 +53,17 @@ public class JwtUtil {
     public Long parseAccessToken(String accessToken) {
         log.info("accessToken: " + accessToken);
 
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(accessToken)
-                .getBody();
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
 
-        Long id = claims.get("id", Long.class);
-        log.info("id: " + id);
-        if(id == null) {
-            log.info("@@@@@@@@@@@없어");
+            return claims.get("id", Long.class);
+        } catch (JwtException e) {
+            e.printStackTrace();
+            throw new InvalidTokenException();
         }
-
-        return id;
     }
 }


### PR DESCRIPTION
기존에는 유효하지 않은 토큰이 주어졌을 경우 null을 반환하고 있었습니다.
그래서 SecurityContext에 null값이 저장되는 문제가 있었습니다.
따라서 주어진 토큰 파싱에 실패했을 경우 null을 반환하지 않고 InvalidTokenException을 던지도록 수정했습니다.