### PR TITLE
예약, 회고 작성할 때 필수 입력 항목 빠트렸는지 검사하라

### DIFF
--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -77,7 +77,7 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
       </TextFieldWrap>
 
       <DialogActions>
-        <Button variant="contained" size="small">
+        <Button disabled={!(date && plan)} variant="contained" size="small">
           제출
         </Button>
         <Button variant="outlined" size="small">

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -77,7 +77,7 @@ export default function ReservationDialog({ open, onClose }: PropsType) {
       </TextFieldWrap>
 
       <DialogActions>
-        <Button disabled={!(date && plan)} variant="contained" size="small">
+        <Button disabled={!date || !plan} variant="contained" size="small">
           제출
         </Button>
         <Button variant="outlined" size="small">

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -29,8 +29,10 @@ const RetrospectionModal: React.FC = () => {
   const dispatch = useDispatch();
   const { retrospections } = useAppSelector((state) => state.retrospections);
 
+  const characterMinimum = 100;
   const characterLimit = 1000;
-  const isMinimum = retrospections.length > 100;
+
+  const isMinimum = retrospections.length > characterMinimum;
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     dispatch(writeRetrospection(event.target.value));
@@ -53,7 +55,7 @@ const RetrospectionModal: React.FC = () => {
           <CloseIcon />
         </IconButton>
         <TextField
-          inputProps={{ maxLength: characterLimit, minLength: 100 }}
+          inputProps={{ maxLength: characterLimit, minLength: characterMinimum }}
           label='회고'
           placeholder='회고를 입력해주세요.'
           helperText={`${retrospections.length} /${characterLimit}`}

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -30,7 +30,7 @@ const RetrospectionModal: React.FC = () => {
   const { retrospections } = useAppSelector((state) => state.retrospections);
 
   const characterMinimum = 100;
-  const characterLimit = 1000;
+  const characterMaximum = 1000;
 
   const isMinimum = retrospections.length > characterMinimum;
 
@@ -55,10 +55,10 @@ const RetrospectionModal: React.FC = () => {
           <CloseIcon />
         </IconButton>
         <TextField
-          inputProps={{ maxLength: characterLimit, minLength: characterMinimum }}
+          inputProps={{ maxLength: characterMaximum, minLength: characterMinimum }}
           label='회고'
           placeholder='회고를 입력해주세요.'
-          helperText={`${retrospections.length} /${characterLimit}`}
+          helperText={`${retrospections.length} /${characterMaximum}`}
           value={retrospections}
           onChange={handleChange}
           style={{ margin: '1rem 3rem 1rem 0' }}

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -26,10 +26,11 @@ const ButtonWrap = styled.div({
 });
 
 const RetrospectionModal: React.FC = () => {
-  const characterLimit = 500;
-
   const dispatch = useDispatch();
   const { retrospections } = useAppSelector((state) => state.retrospections);
+
+  const characterLimit = 1000;
+  const isMinimum = retrospections.length > 100;
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     dispatch(writeRetrospection(event.target.value));
@@ -68,7 +69,10 @@ const RetrospectionModal: React.FC = () => {
           <Button variant='outlined' size='small'>
             취소
           </Button>
-          <Button variant='contained' size='small'>
+          <Button
+            variant='contained' size='small'
+            disabled={!isMinimum}
+          >
             제출
           </Button>
         </ButtonWrap>


### PR DESCRIPTION
현재는 아무정보를 입력하지않아도 제출을 할수있습니다
그것을 방지하기위해 예약모달에서 날짜와 계획을 입력한경우만 제출할수있도록 작업했습니다
회고모달에서도 최소 100자이상 1000자이하로 제출할수있게끔 작업했습니다

### 예약모달
![Oct-14-2022 01-27-29](https://user-images.githubusercontent.com/57708817/195653081-04630c21-e6b6-4fb7-9d6b-9ba51f6559b4.gif)

### 회고모달
![Oct-14-2022 01-27-18](https://user-images.githubusercontent.com/57708817/195653056-612457b3-b279-4e9d-bac9-ccf3b9b1f706.gif)
