### PR TITLE
ReservationQueryController에 `@CrossOrigin` 어노테이션을 추가하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ReservationQueryController.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 /**
  * 예약 조회 컨트롤러
  */
+@CrossOrigin
 @RequestMapping("/reservations")
 @RestController
 public class ReservationQueryController {


### PR DESCRIPTION
`CORS` 에러를 해결하기 위해 컨트롤러 선언부에 `@CrossOrigin` 어노테이션을 추가했습니다.