### PR TITLE
회고 저장 api 작업

### DIFF
--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -13,6 +13,7 @@ import { toggleRetrospectModal } from '../redux/retrospectionSlice';
 
 import ReservationDialog from '../components/reservation/ReservationDialog';
 import ReservationsTable from '../components/reservations/ReservationsTable';
+
 import RetrospectionModal from './Retrospection';
 
 import { fetchReservation } from '../services/reservations';

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -13,6 +13,7 @@ import { toggleRetrospectModal } from '../redux/retrospectionSlice';
 
 import ReservationDialog from '../components/reservation/ReservationDialog';
 import ReservationsTable from '../components/reservations/ReservationsTable';
+import RetrospectionModal from './Retrospection';
 
 import RetrospectionModal from './Retrospection';
 import { fetchReservation } from '../services/reservations';

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -15,8 +15,8 @@ import ReservationDialog from '../components/reservation/ReservationDialog';
 import ReservationsTable from '../components/reservations/ReservationsTable';
 import RetrospectionModal from './Retrospection';
 
-import RetrospectionModal from './Retrospection';
 import { fetchReservation } from '../services/reservations';
+import { fetchRetrospection } from '../services/retrospection';
 
 const Container = styled.div({
   display: 'flex',
@@ -59,7 +59,7 @@ export default function Reservations() {
     dispatch(toggleRetrospectModal());
   };
 
-  const { mutate, isLoading } = useMutation(fetchReservation, {
+  const { mutate: reservationMutate, isLoading } = useMutation(fetchReservation, {
     onSuccess: () => {
       alert('예약이 신청되셨습니다.');
     },
@@ -69,7 +69,7 @@ export default function Reservations() {
   });
 
   const onClickApplyReservation = () => {
-    mutate({
+    reservationMutate({
       date,
       plan,
     });
@@ -80,6 +80,22 @@ export default function Reservations() {
       <LinearProgress />
     );
   }
+
+  const { mutate: retrospectiveMutate } = useMutation(fetchRetrospection, {
+    onSuccess: () => {
+      alert('회고가 제출되었습니다.');
+    },
+    onError: () => {
+      alert('회고 제출에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+
+  const onClickApplyRetrospection = () => {
+    retrospectiveMutate({
+      id: 2,
+      retrospective: '자바스크립트 공부하기 회고',
+    });
+  };
 
   return (
     <Container>
@@ -109,6 +125,6 @@ export default function Reservations() {
           onOpenRetrospectModal={onClicktoggleRetrospectModal}
         />
       </Wrap>
-    </Container>
+    </Container >
   );
 }

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -49,7 +49,7 @@ export default function Reservations() {
   const dispatch = useAppDispatch();
 
   const { isOpenReservationsModal, date, plan } = useAppSelector(get('reservations'));
-  const { isOpenRetrospectModal } = useAppSelector(get('retrospections'));
+  const { isOpenRetrospectModal, retrospections } = useAppSelector(get('retrospections'));
 
   const onClicktoggleReservationsModal = () => {
     dispatch(toggleReservationsModal());
@@ -92,8 +92,8 @@ export default function Reservations() {
 
   const onClickApplyRetrospection = () => {
     retrospectiveMutate({
-      id: 2,
-      retrospective: '자바스크립트 공부하기 회고',
+      id: 1,
+      retrospections: retrospections,
     });
   };
 
@@ -107,6 +107,7 @@ export default function Reservations() {
       <RetrospectionModal
         open={isOpenRetrospectModal}
         onClose={onClicktoggleRetrospectModal}
+        onApply={onClickApplyRetrospection}
       />
 
       <Wrap>

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -60,7 +60,7 @@ export default function Reservations() {
     dispatch(toggleRetrospectModal());
   };
 
-  const { mutate: reservationMutate, isLoading } = useMutation(fetchReservation, {
+  const { mutate: reservationMutate, isLoading: reservationIsLoading } = useMutation(fetchReservation, {
     onSuccess: () => {
       alert('예약이 신청되셨습니다.');
     },
@@ -76,13 +76,7 @@ export default function Reservations() {
     });
   };
 
-  if (isLoading) {
-    return (
-      <LinearProgress />
-    );
-  }
-
-  const { mutate: retrospectiveMutate } = useMutation(fetchRetrospection, {
+  const { mutate: retrospectiveMutate, isLoading: retrospectiveIsLoading } = useMutation(fetchRetrospection, {
     onSuccess: () => {
       alert('회고가 제출되었습니다.');
     },
@@ -97,6 +91,12 @@ export default function Reservations() {
       retrospections: retrospections,
     });
   };
+
+  if (reservationIsLoading || retrospectiveIsLoading) {
+    return (
+      <LinearProgress />
+    );
+  }
 
   return (
     <Container>

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -10,8 +10,6 @@ import { writeRetrospection } from '../../redux/retrospectionSlice';
 
 import { useAppSelector } from '../../hooks';
 
-import { fetchRetrospection } from '../../services/retrospection';
-
 const Wrap = styled.div({
   display: 'flex',
   padding: '3rem',
@@ -44,10 +42,6 @@ const RetrospectionModal: React.FC<Props> = ({ open, onClose }: Props) => {
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     dispatch(writeRetrospection(event.target.value));
-  };
-
-  const handleSubmit = ({ id, retrospective }: { id: number, retrospective: string }) => {
-    fetchRetrospection({ id, retrospective });
   };
 
   return (

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -27,10 +27,11 @@ const ButtonWrap = styled.div({
 
 interface Props {
   open: boolean,
-  onClose: React.ReactEventHandler
+  onClose: React.ReactEventHandler,
+  onApply: React.ReactEventHandler,
 }
 
-const RetrospectionModal: React.FC<Props> = ({ open, onClose }: Props) => {
+const RetrospectionModal: React.FC<Props> = ({ open, onClose, onApply }: Props) => {
   const dispatch = useDispatch();
 
   const { retrospections } = useAppSelector((state) => state.retrospections);
@@ -83,6 +84,7 @@ const RetrospectionModal: React.FC<Props> = ({ open, onClose }: Props) => {
           <Button
             variant='contained' size='small'
             disabled={!isMinimum}
+            onClick={onApply}
           >
             제출
           </Button>

--- a/app-web/src/pages/Retrospection/RetrospectionModal.tsx
+++ b/app-web/src/pages/Retrospection/RetrospectionModal.tsx
@@ -10,6 +10,8 @@ import { writeRetrospection } from '../../redux/retrospectionSlice';
 
 import { useAppSelector } from '../../hooks';
 
+import { fetchRetrospection } from '../../services/retrospection';
+
 const Wrap = styled.div({
   display: 'flex',
   padding: '3rem',
@@ -26,11 +28,11 @@ const ButtonWrap = styled.div({
 });
 
 interface Props {
-  open : boolean,
-  onClose : React.ReactEventHandler
+  open: boolean,
+  onClose: React.ReactEventHandler
 }
 
-const RetrospectionModal: React.FC<Props> = ({ open, onClose } : Props) => {
+const RetrospectionModal: React.FC<Props> = ({ open, onClose }: Props) => {
   const dispatch = useDispatch();
 
   const { retrospections } = useAppSelector((state) => state.retrospections);
@@ -42,6 +44,10 @@ const RetrospectionModal: React.FC<Props> = ({ open, onClose } : Props) => {
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
     dispatch(writeRetrospection(event.target.value));
+  };
+
+  const handleSubmit = ({ id, retrospective }: { id: number, retrospective: string }) => {
+    fetchRetrospection({ id, retrospective });
   };
 
   return (

--- a/app-web/src/services/api.ts
+++ b/app-web/src/services/api.ts
@@ -10,8 +10,8 @@ const api = axios.create({
 export const request = ({ ...options }) => {
   const token = loadItem('accessToken');
   api.defaults.headers.common.Authorization = token ? `Bearer ${token}` : '';
-  const onSuccess = (response:any) => response;
-  const onError = (error:any) => {
+  const onSuccess = (response: any) => response;
+  const onError = (error: any) => {
     return error;
   };
 
@@ -22,11 +22,11 @@ export const getSeats = () => {
   return api.get('/seats');
 };
 
-export const getSeatDetail = (seatNumber:number) => {
+export const getSeatDetail = (seatNumber: number) => {
   return request({ url: `/seat/${seatNumber}`, method: 'get' });
 };
 
-export const seatReservation = async ({ seatNumber }:{ seatNumber:number }) => {
+export const seatReservation = async ({ seatNumber }: { seatNumber: number }) => {
   try {
     return await request({ url: `/seat-reservation/${seatNumber}`, method: 'post' });
   } catch (err) {

--- a/app-web/src/services/retrospection.ts
+++ b/app-web/src/services/retrospection.ts
@@ -1,9 +1,21 @@
-import { request } from './api';
+import axios from 'axios';
 
-export const fetchRetrospection = ({ id, retrospective }: { id: number, retrospective: string }) => {
-  return request({
+import { loadItem } from './stoage';
+
+const BASE_URL = 'https://api.codesoom-myseat.site';
+
+const api = axios.create({
+  baseURL: BASE_URL,
+});
+
+export const fetchRetrospection = ({ id, retrospections }: { id: number, retrospections: string }) => {
+  console.log(id, retrospections);
+  const accessToken = loadItem('accessToken');
+
+  return api({
     method: 'post',
-    url: `/res/reservations/${id}/retrospectives`,
-    data: { retrospective },
+    url: `/reservations/${id}/retrospectives`,
+    headers: { Authorization: `Bearer ${accessToken}` },
+    data: { retrospective: retrospections },
   });
 };

--- a/app-web/src/services/retrospection.ts
+++ b/app-web/src/services/retrospection.ts
@@ -9,7 +9,6 @@ const api = axios.create({
 });
 
 export const fetchRetrospection = ({ id, retrospections }: { id: number, retrospections: string }) => {
-  console.log(id, retrospections);
   const accessToken = loadItem('accessToken');
 
   return api({

--- a/app-web/src/services/retrospection.ts
+++ b/app-web/src/services/retrospection.ts
@@ -1,0 +1,9 @@
+import { request } from './api';
+
+export const fetchRetrospection = ({ id, retrospective }: { id: number, retrospective: string }) => {
+  return request({
+    method: 'post',
+    url: `/res/reservations/${id}/retrospectiveservations`,
+    data: { retrospective },
+  });
+};

--- a/app-web/src/services/retrospection.ts
+++ b/app-web/src/services/retrospection.ts
@@ -3,7 +3,7 @@ import { request } from './api';
 export const fetchRetrospection = ({ id, retrospective }: { id: number, retrospective: string }) => {
   return request({
     method: 'post',
-    url: `/res/reservations/${id}/retrospectiveservations`,
+    url: `/res/reservations/${id}/retrospectives`,
     data: { retrospective },
   });
 };


### PR DESCRIPTION
회고 저장 api를 호출하기 위해 fetchRetrospection 함수를 만들었습니다. 
회고 저장 성공 시 '회고가 제출되었습니다.' 알람이 뜨고 
회고 저장 실패 시 '회고 제출에 실패했습니다. 다시 시도해주세요.' 알람이 발생합니다.