### PR TITLE
배포 스크립트를 정의하라

### DIFF
--- a/app-web/package.json
+++ b/app-web/package.json
@@ -9,7 +9,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "gh-pages -o upstream -d dist",
+    "deploy": "npm run build && echo 'space.codesoom.com' > dist/CNAME && cp dist/index.html dist/404.html && gh-pages -o upstream -d dist",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
배포를 하기전에 build를 해야됩니다. deploy명령에 build가 없어서 build를 하고 나서 배포하게 합니다.
도메인을 `space.codesoom.com`으로 변경했습니다. github pages는 최상단 directory에 CNAME파일이 있어야합니다. 그래서 배포하기전에 파일을
추가하고 배포합니다.
GitHub Pages에서 경로가 없을 경우 index.html을 복사한 404.html으로 fallback되도록 스크립트에 복사하는 명령어를 추가했습니다.