### PR TITLE
함수 이름을 변경하라

### DIFF
--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -4,9 +4,10 @@ import styled from '@emotion/styled';
 
 import { Button, Dialog, DialogTitle, TextField } from '@mui/material';
 
-import { writeRetrospectives } from '../../redux/retrospectivesSlice';
+import { saveRetrospectives } from '../../redux/retrospectivesSlice';
 
 import { useAppSelector } from '../../hooks';
+import { get } from '../../utils';
 
 const Wrap = styled.div({
   display: 'flex',
@@ -42,7 +43,7 @@ interface Props {
 const RetrospectivesModal: React.FC<Props> = ({ open, onClose, onApply }: Props) => {
   const dispatch = useDispatch();
 
-  const { retrospectives } = useAppSelector((state) => state.retrospectives);
+  const { retrospectives } = useAppSelector(get('retrospectives'));
 
   const characterMinimum = 100;
   const characterMaximum = 1000;
@@ -50,7 +51,7 @@ const RetrospectivesModal: React.FC<Props> = ({ open, onClose, onApply }: Props)
   const isMinimum = retrospectives.length > characterMinimum;
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    dispatch(writeRetrospectives(event.target.value));
+    dispatch(saveRetrospectives(event.target.value));
   };
 
   return (

--- a/app-web/src/redux/retrospectivesSlice.tsx
+++ b/app-web/src/redux/retrospectivesSlice.tsx
@@ -20,7 +20,7 @@ const { reducer, actions } = createSlice({
       ...state,
       isOpenRetrospectModal: !state.isOpenRetrospectModal,
     }),
-    writeRetrospectives: (state, { payload }) => {
+    saveRetrospectives: (state, { payload }) => {
       return {
         ...state,
         retrospectives: payload,
@@ -39,7 +39,7 @@ const { reducer, actions } = createSlice({
 
 export const {
   toggleRetrospectModal,
-  writeRetrospectives,
+  saveRetrospectives,
   resetRetrospectives,
   selectResetRetrospectiveId,
 } = actions;


### PR DESCRIPTION
기존 회고 작성을 위한 `writeRetrospectives` 함수 이름을
회고 작성 뿐만 아닌, 상세조회 값을 저장하기 위해
`saveRetrospectives` 로 변경하였습니다.