### PR TITLE
예약이 2개 이상일 때 예약 목록을 불러오지 못하는 문제를 수정하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -30,8 +30,6 @@ public class User {
 
     private String password;
 
-    @OneToOne(mappedBy = "user")
-    private Reservation reservation;
 
     @OneToOne
     @JoinColumn(name = "seat_id")
@@ -56,6 +54,6 @@ public class User {
     public void cancelReservation() {
         log.info("예약 취소");
 
-        reservation = null;
+//        reservation = null;
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationCancelService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/ReservationCancelService.java
@@ -39,9 +39,9 @@ public class ReservationCancelService {
             User user,
             Seat seat
     ) {
-        Reservation reservation = user.getReservation();
+//        Reservation reservation = user.getReservation();
         user.cancelReservation();
-        reservationRepo.delete(reservation);
+//        reservationRepo.delete(reservation);
         seat.cancelReservation();
     }
 


### PR DESCRIPTION
예약이 2개 이상일 때 500응답과 함께 에러가 발생합니다.
에러의 원인은 사용자를 조회할 때, reservation테이블과 같이 join할 때
양방향으로 join하다 보니 반환되어야 하는 row의 개수가 2개 이상이 되는
문제가 발생했습니다.
따라서 User entity에서는 reservation을 알지 못하도록 수정했습니다.