### PR TITLE
예약목록을 props로 사용할 수 있게 상위컴포넌트로 호출위치를 변경하라

### DIFF
--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -98,6 +98,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
     </Box>
   );
 }
+
 interface Props {
   onOpenReservationModal: React.ReactEventHandler,
   onOpenRetrospectModal: React.ReactEventHandler

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -1,9 +1,5 @@
 import * as React from 'react';
 
-import { useDispatch } from 'react-redux';
-
-import { useQuery } from 'react-query';
-
 import { styled } from '@mui/material/styles';
 
 import {
@@ -21,8 +17,6 @@ import {
 } from '@mui/material';
 import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 
-import { getReservation } from '../../services/reservations';
-
 import { selectResetRetrospectiveId } from '../../redux/retrospectivesSlice';
 import { selectReservationId } from '../../redux/reservationsSlice';
 
@@ -30,6 +24,7 @@ import FirstPageIcon from '@mui/icons-material/FirstPage';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 import LastPageIcon from '@mui/icons-material/LastPage';
+import { useAppDispatch } from '../../hooks';
 
 interface TablePaginationActionsProps {
   count: number;
@@ -100,8 +95,16 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 }
 
 interface Props {
-  onOpenReservationModal: React.ReactEventHandler,
+  onOpenReservationModal : React.ReactEventHandler,
   onOpenRetrospectModal: React.ReactEventHandler
+  isLoading: boolean,
+  isError: boolean,
+  reservations: {
+    id: number,
+    date: string,
+    content: string,
+    status:string
+  }[]
 }
 
 interface Reservations {
@@ -115,9 +118,14 @@ type StatusType = {
   [key: string]: string;
 };
 
-export default function ReservationsTable({ onOpenReservationModal, onOpenRetrospectModal }: Props) {
-  const dispatch = useDispatch();
-
+export default function ReservationsTable({
+  onOpenReservationModal,
+  onOpenRetrospectModal,
+  isLoading,
+  isError,
+  reservations,
+}: Props) {
+  const dispatch = useAppDispatch();
   const [page, setPage] = React.useState(0);
 
   const rowsPerPage = 10;
@@ -151,9 +159,6 @@ export default function ReservationsTable({ onOpenReservationModal, onOpenRetros
     'RETROSPECTIVE_WAITING': '회고 작성전',
   };
 
-  const { isLoading, data, isError } = useQuery('reservations', getReservation, {
-    retry: 1,
-  });
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -162,8 +167,6 @@ export default function ReservationsTable({ onOpenReservationModal, onOpenRetros
   if (isError) {
     return <div>Error</div>;
   }
-
-  const { reservations } = data;
 
   return (
     <TableContainer component={Paper}>
@@ -178,7 +181,7 @@ export default function ReservationsTable({ onOpenReservationModal, onOpenRetros
         </TableHead>
 
         <TableBody>
-          {reservations.slice(startRow, endRow).map(({ id, date, content, status }: Reservations) => (
+          {reservations.slice(startRow, endRow).map(({ id, date, content, status }:Reservations) => (
             <TableRow key={id}>
               <TableCell>{date}</TableCell>
               <TableCell align="left">{content}</TableCell>

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import { Button, LinearProgress } from '@mui/material';
 
-import { useMutation } from 'react-query';
+import { useMutation, useQuery } from 'react-query';
 
 import { useAppDispatch, useAppSelector } from '../hooks';
 
@@ -13,10 +13,9 @@ import { resetRetrospectives, toggleRetrospectModal } from '../redux/retrospecti
 
 import ReservationDialog from '../components/reservation/ReservationDialog';
 import ReservationsTable from '../components/reservations/ReservationsTable';
-
 import RetrospectivesModal from './Retrospectives';
 
-import { fetchReservation } from '../services/reservations';
+import { fetchReservation, getReservation } from '../services/reservations';
 import { fetchRetrospectives } from '../services/retrospectives';
 
 const Container = styled.div({
@@ -96,6 +95,10 @@ export default function Reservations() {
     });
   };
 
+  const { isLoading, data, isError } = useQuery('reservations', getReservation, {
+    retry: 1,
+  });
+
   if (reservationIsLoading || retrospectiveIsLoading) {
     return (
       <LinearProgress />
@@ -129,6 +132,9 @@ export default function Reservations() {
         <ReservationsTable
           onOpenReservationModal={onClicktoggleReservationsModal}
           onOpenRetrospectModal={onClicktoggleRetrospectModal}
+          isLoading={isLoading}
+          reservations={data?.reservations}
+          isError={isError}
         />
       </Wrap>
     </Container >


### PR DESCRIPTION
ReservationTable에서 예약목록 data를 받아오던 코드를 Reservations으로 옮겼습니다.