### PR TITLE
예약 응답 데이터를 api문서와 일치시켜라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
@@ -11,13 +11,13 @@ public class ReservationResponse {
 
     private Long id;
     private String date;
-    private String plan;
+    private String content;
     private String status;
 
     public ReservationResponse(Reservation reservation) {
         this.id = reservation.getId();
         this.date = reservation.getDate();
-        this.plan = reservation.getPlan().getContent();
+        this.content = reservation.getPlan().getContent();
         this.status = reservation.getStatus().name();
     }
 


### PR DESCRIPTION
기존에는 예약 응답 데이터 중 계획이 plan이라는 이름으로 설정되어 있었습니다.
api 문서에서 이를 content로 수정했는데, 실제 응답하는 데이터는 수정되지 않아서 여전히 plan을 응답하고 있었습니다.
따라서 응답 데이터도 content로 수정했습니다.