### PR TITLE
상세보기를 클릭했을때 작성한 예약을 보게하라

### DIFF
--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -23,6 +23,7 @@ import { get } from '../../utils';
 import { saveDate, saveContent } from '../../redux/reservationsSlice';
 
 import { getReservations, reservationsKeys } from '../../services/reservations';
+import { CircularProgress } from '@mui/material';
 
 const TextFieldWrap = styled.div({
   display: 'flex',
@@ -48,30 +49,37 @@ const Text = styled(TextField)({
   margin: '1rem 3rem 1rem 0',
 });
 
+const DateTitle = styled.h1({
+  margin: '0',
+  fontSize: '1.3rem',
+});
+
+const TextTitle = styled.h1({
+  marginBottom: '1rem',
+  fontSize: '1.3rem',
+});
+
+const TextBox = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: '20rem',
+  overflow: 'auto',
+  marginBottom: '2rem',
+
+  'p': {
+    margin: '0 0 1rem 0',
+  },
+});
+
 interface Props {
-  open: boolean,
   onClose: React.ReactEventHandler,
   onApply: React.ReactEventHandler
 }
 
-export default function ReservationDialog({ open, onClose, onApply }: Props) {
+export default function ReservationDialog({ onClose, onApply }: Props) {
   const dispatch = useDispatch();
 
-  const { date, content } = useAppSelector(get('reservations'));
-
-  const id = 2;
-
-  const { isLoading, data, isError } = useQuery(
-    reservationsKeys.reservationsById(id),
-    () => getReservations(id), { retry: 1 });
-
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
-
-  if (isError) {
-    return <div>Error</div>;
-  }
+  const { date, content, id, isDetail } = useAppSelector(get('reservations'));
 
   const handleChange = (value: dayjs.Dayjs | null) => {
     dispatch(
@@ -79,40 +87,64 @@ export default function ReservationDialog({ open, onClose, onApply }: Props) {
     );
   };
 
+  const { isLoading, data } = useQuery(
+    reservationsKeys.reservationsById(id),
+    () => getReservations(id), { retry: 1 });
+
+  if (isLoading) {
+    return <CircularProgress />;
+  }
+
   return (
     <Dialog
-      open={open}
+      open={true}
       onClose={onClose}
       aria-labelledby="form-dialog-title"
     >
-      <Title>
-        공부방 예약하기
-      </Title>
+      {!isDetail && (
+        <Title>
+          공부방 예약하기
+        </Title>
+      )}
+
 
       <TextFieldWrap>
-        <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <DatePicker
-            label="방문일자"
-            value={date === null ? null : dayjs(date)}
-            onChange={(value) => handleChange(value)}
-            renderInput={(params) => {
-              return (<TextField {...params} />);
-            }}
-          />
-        </LocalizationProvider>
+        {isDetail && (<DateTitle>예약일 : {data.date}</DateTitle>)}
+        {!isDetail && (
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <DatePicker
+              label="방문일자"
+              value={date === null ? null : dayjs(date)}
+              onChange={(value) => handleChange(value)}
+              renderInput={(params) => {
+                return (<TextField {...params} />);
+              }}
+            />
+          </LocalizationProvider>
+        )}
 
-        <Text
-          label="계획"
-          value={content}
-          onChange={(e) => {
-            dispatch(saveContent(e.target.value));
-          }}
-          variant="outlined"
-          multiline
-          rows={3}
-          placeholder="계획을 입력해주세요."
-          fullWidth
-        />
+        {isDetail && (
+          <>
+            <TextTitle>계획</TextTitle>
+            <TextBox>{data.content.split('\n').map((line:string) => (<p>{line}</p>))}</TextBox>
+          </>
+        )
+        }
+        {!isDetail && (
+          <Text
+            label="계획"
+            value={content}
+            onChange={(e) => {
+              dispatch(saveContent(e.target.value));
+            }}
+            variant="outlined"
+            multiline
+            rows={3}
+            placeholder="계획을 입력해주세요."
+            fullWidth
+          />
+        )}
+
         <ButtonWrap>
           <Button variant="outlined" size="small" onClick={onClose}>
             취소

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -76,16 +76,8 @@ interface Props {
   onApply: React.ReactEventHandler
 }
 
-export default function ReservationDialog({ onClose, onApply }: Props) {
-  const dispatch = useDispatch();
-
-  const { date, content, id, isDetail } = useAppSelector(get('reservations'));
-
-  const handleChange = (value: dayjs.Dayjs | null) => {
-    dispatch(
-      saveDate(value === null ? null : dayjs(value).format('YYYY-MM-DD')),
-    );
-  };
+function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler }) {
+  const { id } = useAppSelector(get('reservations'));
 
   const { isLoading, data } = useQuery(
     reservationsKeys.reservationsById(id),
@@ -96,54 +88,61 @@ export default function ReservationDialog({ onClose, onApply }: Props) {
   }
 
   return (
-    <Dialog
-      open={true}
-      onClose={onClose}
-      aria-labelledby="form-dialog-title"
-    >
-      {!isDetail && (
-        <Title>
+    <TextFieldWrap>
+      <DateTitle>예약일 : {data.date}</DateTitle>
+
+      <TextTitle>계획</TextTitle>
+      <TextBox>{data.content.split('\n').map((line:string) => (<p>{line}</p>))}</TextBox>
+
+      <ButtonWrap>
+        <Button variant="outlined" size="small" onClick={onClose}>
+            취소
+        </Button>
+      </ButtonWrap>
+    </TextFieldWrap>
+  );
+}
+
+function ApplyReservationDialog({ onClose, onApply }:Props) {
+  const dispatch = useDispatch();
+
+  const { date, content } = useAppSelector(get('reservations'));
+
+  const handleChange = (value: dayjs.Dayjs | null) => {
+    dispatch(
+      saveDate(value === null ? null : dayjs(value).format('YYYY-MM-DD')),
+    );
+  };
+
+  return (
+    <>
+      <Title>
           공부방 예약하기
-        </Title>
-      )}
-
-
+      </Title>
       <TextFieldWrap>
-        {isDetail && (<DateTitle>예약일 : {data.date}</DateTitle>)}
-        {!isDetail && (
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DatePicker
-              label="방문일자"
-              value={date === null ? null : dayjs(date)}
-              onChange={(value) => handleChange(value)}
-              renderInput={(params) => {
-                return (<TextField {...params} />);
-              }}
-            />
-          </LocalizationProvider>
-        )}
-
-        {isDetail && (
-          <>
-            <TextTitle>계획</TextTitle>
-            <TextBox>{data.content.split('\n').map((line:string) => (<p>{line}</p>))}</TextBox>
-          </>
-        )
-        }
-        {!isDetail && (
-          <Text
-            label="계획"
-            value={content}
-            onChange={(e) => {
-              dispatch(saveContent(e.target.value));
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <DatePicker
+            label="방문일자"
+            value={date === null ? null : dayjs(date)}
+            onChange={(value) => handleChange(value)}
+            renderInput={(params) => {
+              return (<TextField {...params} />);
             }}
-            variant="outlined"
-            multiline
-            rows={3}
-            placeholder="계획을 입력해주세요."
-            fullWidth
           />
-        )}
+        </LocalizationProvider>
+
+        <Text
+          label="계획"
+          value={content}
+          onChange={(e) => {
+            dispatch(saveContent(e.target.value));
+          }}
+          variant="outlined"
+          multiline
+          rows={3}
+          placeholder="계획을 입력해주세요."
+          fullWidth
+        />
 
         <ButtonWrap>
           <Button variant="outlined" size="small" onClick={onClose}>
@@ -154,6 +153,23 @@ export default function ReservationDialog({ onClose, onApply }: Props) {
           </Button>
         </ButtonWrap>
       </TextFieldWrap>
+    </>
+  );
+}
+
+
+export default function ReservationDialog({ onClose, onApply }: Props) {
+  const { isDetail } = useAppSelector(get('reservations'));
+
+  return (
+    <Dialog
+      open={true}
+      onClose={onClose}
+      aria-labelledby="form-dialog-title"
+    >
+      {isDetail
+        ? <DetailReservationDialog onClose={onClose} />
+        : <ApplyReservationDialog onClose={onClose} onApply={onApply} />}
     </Dialog >
   );
 }

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -3,6 +3,8 @@ import { useDispatch } from 'react-redux';
 
 import styled from '@emotion/styled';
 
+import { useQuery } from 'react-query';
+
 import dayjs from 'dayjs';
 
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -19,6 +21,8 @@ import { useAppSelector } from '../../hooks';
 import { get } from '../../utils';
 
 import { saveDate, saveContent } from '../../redux/reservationsSlice';
+
+import { getReservations, reservationsKeys } from '../../services/reservations';
 
 const TextFieldWrap = styled.div({
   display: 'flex',
@@ -54,6 +58,20 @@ export default function ReservationDialog({ open, onClose, onApply }: Props) {
   const dispatch = useDispatch();
 
   const { date, content } = useAppSelector(get('reservations'));
+
+  const id = 2;
+
+  const { isLoading, data, isError } = useQuery(
+    reservationsKeys.reservationsById(id),
+    () => getReservations(id), { retry: 1 });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError) {
+    return <div>Error</div>;
+  }
 
   const handleChange = (value: dayjs.Dayjs | null) => {
     dispatch(

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { useDispatch } from 'react-redux';
 
 import styled from '@emotion/styled';
@@ -7,6 +8,7 @@ import { useQuery } from 'react-query';
 
 import dayjs from 'dayjs';
 
+import { CircularProgress } from '@mui/material';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -23,7 +25,6 @@ import { get } from '../../utils';
 import { saveDate, saveContent } from '../../redux/reservationsSlice';
 
 import { getReservations, reservationsKeys } from '../../services/reservations';
-import { CircularProgress } from '@mui/material';
 
 const TextFieldWrap = styled.div({
   display: 'flex',

--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -72,8 +72,9 @@ const TextBox = styled.div({
 });
 
 interface Props {
-  onClose: React.ReactEventHandler,
-  onApply: React.ReactEventHandler
+  open : boolean;
+  onClose : React.ReactEventHandler;
+  onApply : React.ReactEventHandler;
 }
 
 function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler }) {
@@ -103,7 +104,10 @@ function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler 
   );
 }
 
-function ApplyReservationDialog({ onClose, onApply }:Props) {
+function ApplyReservationDialog({ onClose, onApply }:{
+  onClose : React.ReactEventHandler;
+  onApply : React.ReactEventHandler;
+}) {
   const dispatch = useDispatch();
 
   const { date, content } = useAppSelector(get('reservations'));
@@ -158,12 +162,12 @@ function ApplyReservationDialog({ onClose, onApply }:Props) {
 }
 
 
-export default function ReservationDialog({ onClose, onApply }: Props) {
+export default function ReservationDialog({ open, onClose, onApply }: Props) {
   const { isDetail } = useAppSelector(get('reservations'));
 
   return (
     <Dialog
-      open={true}
+      open={open}
       onClose={onClose}
       aria-labelledby="form-dialog-title"
     >

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -18,7 +18,7 @@ import {
 import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 
 import { selectResetRetrospectiveId } from '../../redux/retrospectivesSlice';
-import { selectReservationId } from '../../redux/reservationsSlice';
+import { saveIsDetail, selectReservationId } from '../../redux/reservationsSlice';
 
 import FirstPageIcon from '@mui/icons-material/FirstPage';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
@@ -196,6 +196,7 @@ export default function ReservationsTable({
                 <Button
                   onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                     handleClickReservation(e, id);
+                    dispatch(saveIsDetail(true));
                   }}>
                   상세보기
                 </Button>

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -107,12 +107,11 @@ export default function Reservations() {
 
   return (
     <Container>
-      {isOpenReservationsModal && (
-        <ReservationDialog
-          onClose={onClicktoggleReservationsModal}
-          onApply={onClickApplyReservation}
-        />
-      )}
+      <ReservationDialog
+        open={isOpenReservationsModal}
+        onClose={onClicktoggleReservationsModal}
+        onApply={onClickApplyReservation}
+      />
 
       <RetrospectivesModal
         open={isOpenRetrospectModal}

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch, useAppSelector } from '../hooks';
 
 import { get } from '../utils';
 
-import { resetReservations, toggleReservationsModal } from '../redux/reservationsSlice';
+import { resetReservations, saveIsDetail, toggleReservationsModal } from '../redux/reservationsSlice';
 import { resetRetrospectives, toggleRetrospectModal } from '../redux/retrospectivesSlice';
 
 import ReservationDialog from '../components/reservation/ReservationDialog';
@@ -107,11 +107,13 @@ export default function Reservations() {
 
   return (
     <Container>
-      <ReservationDialog
-        open={isOpenReservationsModal}
-        onClose={onClicktoggleReservationsModal}
-        onApply={onClickApplyReservation}
-      />
+      {isOpenReservationsModal && (
+        <ReservationDialog
+          onClose={onClicktoggleReservationsModal}
+          onApply={onClickApplyReservation}
+        />
+      )}
+
       <RetrospectivesModal
         open={isOpenRetrospectModal}
         onClose={onClicktoggleRetrospectModal}
@@ -124,7 +126,10 @@ export default function Reservations() {
 
           <Button
             style={{ fontSize: '2rem' }}
-            onClick={onClicktoggleReservationsModal}
+            onClick={() => {
+              onClicktoggleReservationsModal();
+              dispatch(saveIsDetail(false));
+            }}
           >예약하기
           </Button>
         </Header>

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 interface ReservationState {
   isOpenReservationsModal: boolean;
+  isDetail:boolean;
 
   date: string | null;
   id: number;
@@ -10,6 +11,7 @@ interface ReservationState {
 
 export const initialState: ReservationState = {
   isOpenReservationsModal: false,
+  isDetail: false,
 
   date: null,
   id: 0,
@@ -34,6 +36,10 @@ const reservationsSlice = createSlice({
       ...state,
       content: payload,
     }),
+    saveIsDetail: (state, { payload }) => ({
+      ...state,
+      isDetail: payload,
+    }),
     resetReservations: (state) => ({
       ...state,
       date: initialState.date,
@@ -50,6 +56,7 @@ export const {
   toggleReservationsModal,
   saveDate,
   saveContent,
+  saveIsDetail,
   resetReservations,
   selectReservationId,
 } = reservationsSlice.actions;

--- a/app-web/src/services/reservations.ts
+++ b/app-web/src/services/reservations.ts
@@ -31,3 +31,19 @@ export const fetchReservation = async ({ date, content }:{ date : string, conten
 
   return response;
 };
+
+export const reservationsKeys = {
+  reservationsById: (id : number) => ['retrospectives', id] as const,
+};
+
+export const getReservations = async (id : number) => {
+  const accessToken = loadItem('accessToken');
+
+  const { data } = await api({
+    method: 'get',
+    url: `reservations/${id}`,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return data;
+};


### PR DESCRIPTION
예약하기를 한뒤 예약내역에 나오는 상세보기 버튼을 클릭했을때
예약을 신청한 일자와 계획내용을 볼수있게 작업했습니다

예약 상세내역을 볼수있는 api 작업을했습니다
예약 상세모달인지 예약신청모달인지 구분할수있게 state, action 작업을했습니다
만든 state , action을 이용하여 상세모달, 예약신청모달을 구분할수있게했습니다
예약모달안에서 상세인지 예약신청인지 컴포넌트를 분리하여 상세모달일때만 get api가 호출되게작업했습니다

![Oct-14-2022 22-37-11](https://user-images.githubusercontent.com/57708817/195860615-4d9837a6-5a7b-4b9b-aee2-5cc91887509a.gif)

