### PR TITLE
main브랜치에 머지될 때 마다 배포하라 

### DIFF
--- a/.github/workflows/front-ci.yml
+++ b/.github/workflows/front-ci.yml
@@ -2,9 +2,13 @@ name: FRONT CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["test"]
+    paths:
+      - "app-web/**"
   pull_request:
     branches: ["main"]
+    paths:
+      - "app-web/**"
 
 jobs:
   build:
@@ -14,6 +18,7 @@ jobs:
         working-directory: ./app-web
 
     permissions:
+      id-token: write
       contents: write
 
     steps:
@@ -32,13 +37,14 @@ jobs:
         run: npm run test
       - name: Run lint
         run: npm run lint
-      - name: Create 404.html
+      - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/main'
-        run: cp dist/index.html dist/404.html
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ap-northeast-2
       - name: Deploy
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./app-web/dist
-          cname: space.codesoom.com
+        run: |
+          aws s3 cp dist s3://space.codesoom.com --recursive --exclude index.html --acl public-read --region ap-northeast-2
+          aws s3 cp dist/index.html s3://space.codesoom.com --cache-control max-age=0 --acl public-read --region ap-northeast-2

--- a/.github/workflows/front-ci.yml
+++ b/.github/workflows/front-ci.yml
@@ -2,7 +2,7 @@ name: FRONT CI
 
 on:
   push:
-    branches: ["test"]
+    branches: ["main"]
     paths:
       - "app-web/**"
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+terraform*

--- a/infra/cloud-front.tf
+++ b/infra/cloud-front.tf
@@ -1,0 +1,54 @@
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = aws_s3_bucket.bucket.website_endpoint
+    origin_id   = "S3-Website-${aws_s3_bucket.bucket.website_endpoint}"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.1"]
+    }
+  }
+
+  aliases = [
+    "space.codesoom.com"
+  ]
+
+  viewer_certificate {
+    acm_certificate_arn      = local.acm
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+
+
+  enabled         = true
+  is_ipv6_enabled = true
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-Website-${aws_s3_bucket.bucket.website_endpoint}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    max_ttl                = 31536000
+    default_ttl            = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = local.tags
+}

--- a/infra/policy.tf
+++ b/infra/policy.tf
@@ -1,0 +1,22 @@
+resource "aws_iam_policy" "policy" {
+  name        = "space-codesoom-s3-upload-ci-policy"
+  description = "space.codesoom.com S3 upload CI policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Sid"    = "VisualEditor0",
+        "Effect" = "Allow",
+        "Action" = [
+          "s3:PutObject",
+          "s3:PutObjectAcl"
+        ],
+        "Resource" = [
+          aws_s3_bucket.bucket.arn,
+          "${aws_s3_bucket.bucket.arn}/*",
+        ]
+      },
+    ]
+  })
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  profile = "codesoom"
+  region = "ap-northeast-2"
+}

--- a/infra/role.tf
+++ b/infra/role.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "upload-role" {
+  name = "space-codesoom-web-upload"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = "arn:aws:iam::466782999783:oidc-provider/token.actions.githubusercontent.com"
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:CodeSoom-Project/my-seat:ref:refs/heads/main"
+          },
+          "ForAllValues:StringEquals" = {
+            "token.actions.githubusercontent.com:iss" = "https://token.actions.githubusercontent.com",
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  managed_policy_arns = [
+    aws_iam_policy.policy.arn
+  ]
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "space.codesoom.com"
+
+  acl = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
+
+  tags = local.tags
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,8 @@
+locals {
+  acm = "arn:aws:acm:us-east-1:466782999783:certificate/be52637a-b8da-43e5-bce8-99358955b673"
+
+  tags = {
+    env  = "production",
+    Name = "codesoom"
+  }
+}


### PR DESCRIPTION
프론트 프로젝트를 S3 + CloudFront로 배포하기 위해서 인프라를 구축합니다.
테라폼 코드로 작성했습니다.

main브랜치에 머지될 때 마다 프론트 프로젝트에 변경사항이 있을 경우에만
자동으로 배포할 수 있도록 GitHub Actions scripts를 수정했습니다.