### PR TITLE
서버 파일이 변경되었을 때만 CI를 실행하라

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "app-server/**"
   pull_request:
     branches: [ "main" ]
+    paths:
+      - "app-server/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
지금은 서버 코드가 변경되든, 프론트 코드가 변경되든 서버 CI가 실행되고 있습니다.
서버 코드가 변경되었을 때만 서버 코드가 실행되도록 해야 합니다.
따라서 서버 코드가 변경되었을 때만 실행되도록 paths 옵션을 추가했습니다.

See also
  - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore