### PR TITLE
회고 상세 조회를 할 수 있게 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -61,4 +61,10 @@ public class ControllerErrorAdvice {
     public String handleNotRegisteredReservation(NotOwnedReservationException e) {
         return e.getMessage();
     }
+    
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(RetrospectiveNotFoundException.class)
+    public String handleRetrospectiveNotFound() {
+        return "회고 조회에 실패했습니다.";
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
@@ -2,12 +2,10 @@ package com.codesoom.myseat.controllers.reservations.retrospectives;
 
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.Retrospective;
-import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.RetrospectiveResponse;
 import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.reservations.ReservationQueryService;
 import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveDetailService;
-import com.codesoom.myseat.services.users.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -44,20 +42,17 @@ public class RetrospectiveDetailController {
             @AuthenticationPrincipal UserAuthentication principal,
             @PathVariable Long id
     ) {
-        log.info("###########: " + principal.getId());
         Reservation reservation = reservationQueryService.reservation(id, principal.getId());
         Retrospective retrospective = retrospectiveDetailService.retrospective(id);
         
-        return toResponse(retrospective, reservation.getDate());
+        return toResponse(retrospective);
     }
     
     private RetrospectiveResponse toResponse(
-            Retrospective retrospective,
-            String date
+            Retrospective retrospective
     ) {
         return RetrospectiveResponse.builder()
                 .id(retrospective.getId())
-                .date(date)
                 .content(retrospective.getContent())
                 .build();
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
@@ -20,16 +20,13 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin
 @Slf4j
 public class RetrospectiveDetailController {
-    private final UserService userService;
     private final ReservationQueryService reservationQueryService;
     private final RetrospectiveDetailService retrospectiveDetailService;
 
     public RetrospectiveDetailController(
-            UserService userService,
             ReservationQueryService reservationQueryService, 
             RetrospectiveDetailService retrospectiveDetailService
     ) {
-        this.userService = userService;
         this.reservationQueryService = reservationQueryService;
         this.retrospectiveDetailService = retrospectiveDetailService;
     }
@@ -47,8 +44,8 @@ public class RetrospectiveDetailController {
             @AuthenticationPrincipal UserAuthentication principal,
             @PathVariable Long id
     ) {
-        User user = userService.findById(principal.getId());
-        Reservation reservation = reservationQueryService.reservation(id, user.getId());
+        log.info("###########: " + principal.getId());
+        Reservation reservation = reservationQueryService.reservation(id, principal.getId());
         Retrospective retrospective = retrospectiveDetailService.retrospective(id);
         
         return toResponse(retrospective, reservation.getDate());

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RetrospectiveResponse {
-    Long id;
+    private Long id;
     
-    String content;
+    private String content;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
@@ -11,7 +11,5 @@ import lombok.Getter;
 public class RetrospectiveResponse {
     Long id;
     
-    String date;
-    
     String content;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
@@ -1,0 +1,17 @@
+package com.codesoom.myseat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/** 회고 상세 조회 응답 정보 */
+@Getter
+@Builder
+@AllArgsConstructor
+public class RetrospectiveResponse {
+    Long id;
+    
+    String date;
+    
+    String content;
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/RetrospectiveNotFoundException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/RetrospectiveNotFoundException.java
@@ -1,0 +1,10 @@
+package com.codesoom.myseat.exceptions;
+
+/**
+ * 회고를 찾지 못한 경우 던지는 예외
+ */
+public class RetrospectiveNotFoundException extends RuntimeException {
+    public RetrospectiveNotFoundException() {
+        super();
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/RetrospectiveRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/RetrospectiveRepository.java
@@ -3,5 +3,14 @@ package com.codesoom.myseat.repositories;
 import com.codesoom.myseat.domain.Retrospective;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RetrospectiveRepository extends JpaRepository<Retrospective, Long> {
+import java.util.Optional;
+
+public interface RetrospectiveRepository 
+        extends JpaRepository<Retrospective, Long> {
+    /**
+     * 주어진 예약 id로 조회된 회고를 반환합니다.
+     * @param id 예약 id
+     * @return 조회된 회고
+     */
+    Optional<Retrospective> findByReservationId(Long id);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailService.java
@@ -1,0 +1,33 @@
+package com.codesoom.myseat.services.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.exceptions.RetrospectiveNotFoundException;
+import com.codesoom.myseat.repositories.RetrospectiveRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/** 회고 상세 조회 서비스 */
+@Service
+@Slf4j
+public class RetrospectiveDetailService {
+    private final RetrospectiveRepository retrospectiveRepo;
+
+    public RetrospectiveDetailService(
+            RetrospectiveRepository retrospectiveRepo
+    ) {
+        this.retrospectiveRepo = retrospectiveRepo;
+    }
+
+    /**
+     * 주어진 예약 id로 조회된 회고를 반환합니다.
+     * @param id 예약 id
+     * @return 조회된 회고
+     * @throw RetrospectiveNotFoundException 회고 조회에 실패하면 던집니다.
+     */
+    public Retrospective retrospective(
+            Long id
+    ) {
+        return retrospectiveRepo.findByReservationId(id)
+                .orElseThrow(() -> new RetrospectiveNotFoundException());
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
@@ -97,7 +97,6 @@ class RetrospectiveDetailControllerTest {
         
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(4L))
-                .andExpect(jsonPath("$.date").value("2022-10-18"))
                 .andExpect(jsonPath("$.content").value("잘했다."))
                 .andDo(print())
                 .andReturn();

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
@@ -1,0 +1,105 @@
+package com.codesoom.myseat.controllers.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationQueryService;
+import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveDetailService;
+import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveService;
+import com.codesoom.myseat.services.users.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RetrospectiveDetailController.class)
+class RetrospectiveDetailControllerTest {
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private RetrospectiveService retrospectiveService;
+
+    @MockBean
+    private UserService userService;
+    
+    @MockBean
+    private ReservationQueryService reservationQueryService;
+    
+    @MockBean
+    private RetrospectiveDetailService retrospectiveDetailService;
+
+    @Test
+    @DisplayName("POST /reservations/{id}/retrospectives 요청 시 상태코드 200과 함께 회고를 반환한다")
+    void get_retrospective_returns_retrospective_and_responses_status_code_200() throws Exception {
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+        
+        Plan mockPlan = Plan.builder()
+                .id(2L)
+                .content("코테 풀기")
+                .build();
+        
+        Reservation mockReservation = Reservation.builder()
+                .id(3L)
+                .date("2022-10-18")
+                .user(mockUser)
+                .plan(mockPlan)
+                .build();
+
+        Retrospective mockRetrospective = Retrospective.builder()
+                .id(4L)
+                .content("잘했다.")
+                .reservation(mockReservation)
+                .build();
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn(1L);
+
+        given(userService.findById(1L))
+                .willReturn(mockUser);
+        
+        given(reservationQueryService.reservation(3L, 1L))
+                .willReturn(mockReservation);
+        
+        given(retrospectiveDetailService.retrospective(3L))
+                .willReturn(mockRetrospective);
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn(1L);
+
+        ResultActions result = mockMvc.perform(get("/reservations/{id}/retrospectives", 3L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
+        );
+        
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(4L))
+                .andExpect(jsonPath("$.date").value("2022-10-18"))
+                .andExpect(jsonPath("$.content").value("잘했다."))
+                .andDo(print())
+                .andReturn();
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailServiceTest.java
@@ -1,0 +1,45 @@
+package com.codesoom.myseat.services.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.repositories.RetrospectiveRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+class RetrospectiveDetailServiceTest {
+    private RetrospectiveDetailService service;
+
+    @Mock
+    private RetrospectiveRepository retrospectiveRepo;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        service = new RetrospectiveDetailService(retrospectiveRepo);
+    }
+
+    @Test
+    @DisplayName("retrospective 메서드는 조회된 회고를 반환한다.")
+    void retrospective_returns() {
+        Retrospective mockRetrospective = Retrospective.builder()
+                .id(2L)
+                .content("잘했다.")
+                .build();
+
+        given(retrospectiveRepo.findByReservationId(1L))
+                .willReturn(Optional.of(mockRetrospective));
+
+        Retrospective retrospective
+                = service.retrospective(1L);
+
+        assertThat(retrospective.getId()).isEqualTo(2L);
+        assertThat(retrospective.getContent()).isEqualTo("잘했다.");
+    }
+}


### PR DESCRIPTION
GET /reservations/{id}/retrospectives 회고 상세 조회 API를 구현했습니다.

```bash
$ curl 'https://api.codesoom-myseat.site:8080/reservations/1/retrospectives' -i -X GET \
    -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk'
```
위 curl 명령어를 통해 요청을 확인해보실 수 있습니다.
*요청 시 헤더에 유효한 토큰을 함께 보내주어야 합니다.