### PR TITLE
콜론간격이 맞지않던 코드의 콜론간격을 통일하라

### DIFF
--- a/app-web/.eslintrc.cjs
+++ b/app-web/.eslintrc.cjs
@@ -44,5 +44,7 @@ module.exports = {
 
     "react/jsx-filename-extension": [0],
     "import/extensions": "off",
+
+    "@typescript-eslint/type-annotation-spacing": ["error", { before: false, after: true }]
   }
 };

--- a/app-web/src/components/Modal.tsx
+++ b/app-web/src/components/Modal.tsx
@@ -22,7 +22,7 @@ const OVERLAY_STYLES = {
   zIndex: 1000,
 };
 
-export default function Modal({ open, children, onClose }:any) {
+export default function Modal({ open, children, onClose }: any) {
   if (!open) {
     return null;
   }

--- a/app-web/src/components/details.tsx
+++ b/app-web/src/components/details.tsx
@@ -3,7 +3,7 @@ interface DetailType {
   userName: string;
 }
 
-export default function Detail({ seatNumber, userName }:DetailType) {
+export default function Detail({ seatNumber, userName }: DetailType) {
 
   return (
     <>

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -33,7 +33,7 @@ interface TablePaginationActionsProps {
   onPageChange: (
     event: React.MouseEvent<HTMLButtonElement>,
     newPage: number,
-  ) => void;
+  )=> void;
 }
 
 const StyledTableCell = styled(TableCell)({
@@ -95,7 +95,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 }
 
 interface Props {
-  onOpenReservationModal : React.ReactEventHandler,
+  onOpenReservationModal: React.ReactEventHandler,
   onOpenRetrospectModal: React.ReactEventHandler
   isLoading: boolean,
   isError: boolean,
@@ -103,7 +103,7 @@ interface Props {
     id: number,
     date: string,
     content: string,
-    status:string
+    status: string
   }[]
 }
 
@@ -140,13 +140,13 @@ export default function ReservationsTable({
     setPage(newPage);
   };
 
-  const handleClickReservation = (e: React.MouseEvent<HTMLButtonElement>, id:number) => {
+  const handleClickReservation = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
     onOpenReservationModal(e);
 
     dispatch(selectReservationId(id));
   };
 
-  const handleClickRetrospective = (e: React.MouseEvent<HTMLButtonElement>, id:number) => {
+  const handleClickRetrospective = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
     onOpenRetrospectModal(e);
 
     dispatch(selectResetRetrospectiveId(id));
@@ -182,7 +182,7 @@ export default function ReservationsTable({
         </TableHead>
 
         <TableBody>
-          {reservations.slice(startRow, endRow).map(({ id, date, content, status }:Reservations) => (
+          {reservations.slice(startRow, endRow).map(({ id, date, content, status }: Reservations) => (
             <TableRow key={id}>
               <TableCell align="center">{date}</TableCell>
               <TableCell align="left">{content}</TableCell>

--- a/app-web/src/hooks.ts
+++ b/app-web/src/hooks.ts
@@ -3,5 +3,5 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from './store';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
-export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppDispatch: ()=> AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/app-web/src/redux/reservationsSlice.tsx
+++ b/app-web/src/redux/reservationsSlice.tsx
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 interface ReservationState {
   isOpenReservationsModal: boolean;
-  isDetail:boolean;
+  isDetail: boolean;
 
   date: string | null;
   id: number;

--- a/app-web/src/seatDetailModal.tsx
+++ b/app-web/src/seatDetailModal.tsx
@@ -1,7 +1,7 @@
 import Modal from './components/Modal';
 import Detail from './components/details';
 
-export default function SeatDetailModal({ open, onClose, seatNumber, seatDetail }:any) {
+export default function SeatDetailModal({ open, onClose, seatNumber, seatDetail }: any) {
   if (!seatDetail) {
     return (
       <>

--- a/app-web/src/seatDetailModalContainer.tsx
+++ b/app-web/src/seatDetailModalContainer.tsx
@@ -3,7 +3,7 @@ import { useAppSelector } from './hooks';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { cancelReservation, getSeatDetail, seatReservation } from './services/api';
 
-export default function SeatDetailModalContainer({ open, onClose }:any) {
+export default function SeatDetailModalContainer({ open, onClose }: any) {
   const seatNumber = useAppSelector((state) => state.reservation.seatNumber);
 
   const queryClient = useQueryClient();
@@ -17,7 +17,7 @@ export default function SeatDetailModalContainer({ open, onClose }:any) {
   );
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  const cancel = async ({ seatNumber }: { seatNumber:number }) => {
+  const cancel = async ({ seatNumber }: { seatNumber: number }) => {
     const deleteSeatResult = await cancelReservation({ seatNumber });
     return deleteSeatResult;
   };
@@ -33,7 +33,7 @@ export default function SeatDetailModalContainer({ open, onClose }:any) {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  const reservation = async ({ seatNumber }: { seatNumber:number }) => {
+  const reservation = async ({ seatNumber }: { seatNumber: number }) => {
     const bookingSeatResult = await seatReservation({ seatNumber });
     return bookingSeatResult;
   };

--- a/app-web/src/seats.tsx
+++ b/app-web/src/seats.tsx
@@ -1,6 +1,6 @@
 import Button from './components/Button';
 
-export default function Seats({ seats, onClick }:any) {
+export default function Seats({ seats, onClick }: any) {
   return (
     <>
       {seats?.data?.map(seat => (

--- a/app-web/src/seatsContainer.tsx
+++ b/app-web/src/seatsContainer.tsx
@@ -30,7 +30,7 @@ export default function SeatsContainer() {
     retry: 1,
   });
 
-  const handleChange = (seatNumber:any) => {
+  const handleChange = (seatNumber: any) => {
     dispatch(changeReservationDetailsSeatNumber({ seatNumber }));
   };
 
@@ -42,7 +42,7 @@ export default function SeatsContainer() {
     setIsOpen(false);
   };
 
-  const handleClick = (seatNumber:any) => {
+  const handleClick = (seatNumber: any) => {
     handleChange(seatNumber);
     handleOpen();
   };

--- a/app-web/src/services/reservations.ts
+++ b/app-web/src/services/reservations.ts
@@ -19,7 +19,7 @@ export const getReservation = async () => {
   return data;
 };
 
-export const fetchReservation = async ({ date, content }:{ date : string, content : string }) => {
+export const fetchReservation = async ({ date, content }: { date: string, content: string }) => {
   const accessToken = loadItem('accessToken');
 
   const response = await api({
@@ -33,10 +33,10 @@ export const fetchReservation = async ({ date, content }:{ date : string, conten
 };
 
 export const reservationsKeys = {
-  reservationsById: (id : number) => ['retrospectives', id] as const,
+  reservationsById: (id: number) => ['retrospectives', id] as const,
 };
 
-export const getReservations = async (id : number) => {
+export const getReservations = async (id: number) => {
   const accessToken = loadItem('accessToken');
 
   const { data } = await api({

--- a/app-web/src/services/stoage.ts
+++ b/app-web/src/services/stoage.ts
@@ -1,7 +1,7 @@
-export function saveItem(key:any, value:any) {
+export function saveItem(key: any, value: any) {
   localStorage.setItem(key, value);
 }
 
-export function loadItem(key:any) {
+export function loadItem(key: any) {
   return localStorage.getItem(key);
 }


### PR DESCRIPTION
기존엔 콜론 간격이 eslint 설정이되지않아 통일이안되던현상이있었습니다
@typescript-eslint/type-annotation-spacing속성을 rules에 추가했습니다
before: false
after: true
옵션을 줘서 콜론전에는 간격을 안띄우고 콜론후에는 간격을 띄우게끔 설정했습니다

수정전
<img width="310" alt="image" src="https://user-images.githubusercontent.com/57708817/196338369-32c6e8c0-0e73-4b06-98b2-05619bf6660c.png">

수정후
<img width="292" alt="image" src="https://user-images.githubusercontent.com/57708817/196338418-530c403a-3ac1-4446-85bb-663423ce190e.png">

