### PR TITLE
NotOwnedReservationException의 응답 상태를 404에서 403으로 변경하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -56,7 +56,7 @@ public class ControllerErrorAdvice {
         return e.getMessage();
     }
 
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
     @ExceptionHandler(NotOwnedReservationException.class)
     public String handleNotRegisteredReservation(NotOwnedReservationException e) {
         return e.getMessage();


### PR DESCRIPTION
본인 소유의 예약이 아닐 경우 NotOwnedReservationException을 던지고 있습니다.
해당 오류는 예약 리소스에 접근할 수 없는 경우이므로 403 forbidden이 더 적절하다고 생각되어 변경하였습니다.