### PR TITLE
예약 수정 API

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateController.java
@@ -1,0 +1,45 @@
+package com.codesoom.myseat.controllers.reservations;
+
+import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.security.UserAuthentication;
+import com.codesoom.myseat.services.reservations.ReservationUpdateService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 예약 수정 컨트롤러 */
+@CrossOrigin
+@RequestMapping("/reservations")
+@RestController
+public class ReservationUpdateController {
+
+    private final ReservationUpdateService service;
+
+    public ReservationUpdateController(ReservationUpdateService service) {
+        this.service = service;
+    }
+
+    /**
+     * 예약 수정 정보를 받아 수정합니다.
+     *
+     * @param principal 요청한 회원의 인증 정보
+     * @param id 수정할 예약의 id
+     * @param request 수정 데이터
+     */
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/{id}")
+    public void updateReservation(@AuthenticationPrincipal UserAuthentication principal,
+                                  @PathVariable Long id,
+                                  @RequestBody ReservationRequest request) {
+        service.updateReservation(principal.getId(), id, request);
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
@@ -26,4 +26,8 @@ public class Plan {
     private Long id;
 
     private String content;
+
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -1,6 +1,7 @@
 package com.codesoom.myseat.domain;
 
 import com.codesoom.myseat.converters.ReservationStatusConverter;
+import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.enums.ReservationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
+
+import java.util.Objects;
 
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -52,6 +55,15 @@ public class Reservation {
         if (this.status == null) {
             this.status = ReservationStatus.RETROSPECTIVE_WAITING;
         }
+    }
+
+    public boolean isOwnReservation(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+
+    public void update(ReservationRequest updateData) {
+        this.date = updateData.getDate();
+        this.plan.update(updateData.getContent());
     }
 
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -1,0 +1,40 @@
+package com.codesoom.myseat.services.reservations;
+
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 예약 수정 담당 */
+@Service
+public class ReservationUpdateService {
+
+    private final ReservationRepository repository;
+
+    public ReservationUpdateService(ReservationRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 예약 내용을 수정합니다.
+     *
+     * @param userId 수정을 요청한 회원 id
+     * @param id 예약 id
+     * @param request 수정 데이터
+     * @throws ReservationNotFoundException 주어진 예약 id로 예약을 찾지 못한 경우
+     * @throws NotOwnedReservationException 요청한 회원 소유의 예약이 아닌 경우
+     */
+    @Transactional
+    public void updateReservation(Long userId, Long id, ReservationRequest request) {
+        Reservation reservation = repository.findById(id)
+                .orElseThrow(ReservationNotFoundException::new);
+        if (!reservation.isOwnReservation(userId)) {
+            throw new NotOwnedReservationException();
+        }
+        reservation.update(request);
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateControllerTest.java
@@ -1,0 +1,123 @@
+package com.codesoom.myseat.controllers.reservations;
+
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationUpdateService;
+import com.codesoom.myseat.services.users.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ReservationUpdateController.class)
+class ReservationUpdateControllerTest {
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ReservationUpdateService reservationUpdateService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn(1L);
+
+        given(userService.findById(1L))
+                .willReturn(mockUser);
+    }
+
+    @DisplayName("예약을 성공적으로 수정하면 204 no content를 응답한다.")
+    @Test
+    void PUT_reservation_update_with_204_status() throws Exception {
+        ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+
+        mockMvc.perform(put("/reservations/1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("본인 소유가 아닌 예약 id가 주어지면 403 forbidden를 응답한다.")
+    @Test
+    void PUT_reservation_update_with_403_status() throws Exception {
+        ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+
+        doThrow(NotOwnedReservationException.class)
+                .when(reservationUpdateService)
+                .updateReservation(anyLong(), anyLong(), any(ReservationRequest.class));
+
+        mockMvc.perform(put("/reservations/999")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @DisplayName("찾을 수 없는 예약 id가 주어지면 404 not found를 응답한다.")
+    @Test
+    void PUT_reservation_update_with_404_status() throws Exception {
+        ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+
+        doThrow(ReservationNotFoundException.class)
+                .when(reservationUpdateService)
+                .updateReservation(anyLong(), anyLong(), any(ReservationRequest.class));
+
+        mockMvc.perform(put("/reservations/999")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
@@ -1,0 +1,124 @@
+package com.codesoom.myseat.services.reservations;
+
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationUpdateService 클래스")
+class ReservationUpdateServiceTest {
+
+    @InjectMocks
+    private ReservationUpdateService service;
+
+    @Mock
+    private ReservationRepository repository;
+
+    private final Long USER_ID = 1L;
+
+    @DisplayName("updateReservation 메소드는")
+    @Nested
+    class Describe_update_reservation {
+
+        @DisplayName("주어진 예약 id로 예약을 찾을 수 있고")
+        @Nested
+        class Context_with_exist_reservation {
+
+            private final Long EXIST_ID = 99L;
+            private final User USER = User.builder()
+                    .id(USER_ID)
+                    .name("김철수")
+                    .email("soo@email.com")
+                    .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                    .build();
+            private final Plan PLAN = Plan.builder().content("공부").build();
+            private Reservation RESERVATION;
+
+            @BeforeEach
+            void setUp() {
+                RESERVATION = Reservation.builder()
+                        .user(USER)
+                        .date("2022-10-17")
+                        .plan(PLAN)
+                        .build();
+                given(repository.findById(same(EXIST_ID)))
+                        .willReturn(Optional.of(RESERVATION));
+            }
+
+            @DisplayName("요청한 회원 소유의 예약이면")
+            @Nested
+            class Context_with_own_reservation{
+                @DisplayName("성공적으로 예약을 수정한다")
+                @Test
+                void will_update_successfully() {
+                    //given
+                    ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+
+                    //when
+                    service.updateReservation(USER_ID, EXIST_ID, request);
+
+                    //then
+                    assertThat(RESERVATION.getPlan().getContent()).isEqualTo(request.getContent());
+                    assertThat(RESERVATION.getDate()).isEqualTo(request.getDate());
+                }
+            }
+
+            @DisplayName("요청한 회원이 소유한 예약이 아니면")
+            @Nested
+            class Context_with_not_own_reservation{
+                @DisplayName("예외를 던진다")
+                @Test
+                void will_throw_exception() {
+                    //given
+                    Long NOT_OWNED_USER_ID = 888L;
+                    ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+
+                    //when
+                    assertThrows(NotOwnedReservationException.class,
+                            () -> service.updateReservation(NOT_OWNED_USER_ID, EXIST_ID, request));
+                }
+            }
+        }
+
+        @DisplayName("주어진 예약 id로 예약을 찾지 못하면")
+        @Nested
+        class Context_with_not_exist_reservation {
+
+            private final Long NOT_EXIST_ID = 999L;
+
+            @DisplayName("not found 예외를 던진다")
+            @Test
+            void will_throw_reservation_not_found_exception() {
+                //given
+                ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+                given(repository.findById(same(NOT_EXIST_ID)))
+                        .willReturn(Optional.empty());
+
+                //when & then
+                assertThrows(ReservationNotFoundException.class,
+                        ()-> service.updateReservation(USER_ID, NOT_EXIST_ID, request));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
`PUT /reservations/{id}`요청 시 예약을 수정하는 API를 만들었습니다.

주어진 예약 id로 예약을 찾을 수 없는 경우는 `404 not found`를,
예약을 찾을 수 있지만 요청한 회원의 소유가 아닌 경우는 `403 forbidden`을 응답합니다.

예약 수정에 성공할 경우 `204 no content`를 응답합니다.