### PR TITLE
회고 등록 후 회고작성 전 상태를 회고작성 완료 상태로 변경하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -77,4 +77,8 @@ public class Reservation {
         this.status = ReservationStatus.CANCELED;
     }
 
+    public void completeRetrospective() {
+        this.status = ReservationStatus.RETROSPECTIVE_COMPLETE;
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
@@ -26,9 +26,9 @@ public class Retrospective {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "retrospective_id")
-    Long id;
+    private Long id;
 
-    String content;
+    private String content;
 
     @OneToOne(cascade = PERSIST)
     @JoinColumn(name = "reservation_id")

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveService.java
@@ -42,6 +42,8 @@ public class RetrospectiveService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(ReservationNotFoundException::new);
 
+        reservation.completeRetrospective();
+
         Retrospective retrospective = Retrospective.builder()
                 .reservation(reservation)
                 .content(content)

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
 
+import static com.codesoom.myseat.enums.ReservationStatus.RETROSPECTIVE_COMPLETE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -84,6 +85,35 @@ class RetrospectiveServiceTest {
 
         assertThatThrownBy(() -> service.createRetrospective(mockUser, 1000L, "잘했다."))
                 .isInstanceOf(NotOwnedReservationException.class);
+    }
+
+    @Test
+    @DisplayName("회고 작성이 완료가 되면 RETROSPECTIVE_COMPLETE으로 반환한다.")
+    void status_return_RETROSPECTIVE_COMPLETE() {
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        Reservation mockReservation = Reservation.builder()
+                .id(1L)
+                .user(mockUser)
+                .build();
+
+        Retrospective mockRetrospective = Retrospective.builder()
+                .content("잘했다.")
+                .reservation(mockReservation)
+                .build();
+
+        given(reservationRepository.findById(1L)).willReturn(Optional.of(mockReservation));
+        given(reservationRepository.existsByIdAndUser_Id(1L, mockUser.getId())).willReturn(true);
+        given(retrospectiveRepository.save(any())).willReturn(mockRetrospective);
+
+        Retrospective retrospective = service.createRetrospective(mockUser, 1L, "잘했다.");
+
+        assertThat(retrospective.getReservation().getStatus()).isEqualTo(RETROSPECTIVE_COMPLETE);
     }
 
 }

--- a/app-server/http-request/local/회고작성.http
+++ b/app-server/http-request/local/회고작성.http
@@ -3,5 +3,5 @@ Content-Type: application/json;charset=UTF-8
 Authorization: Bearer
 
 {
-  "retrospective" : "잘했다."
+  "content" : "잘했다."
 }


### PR DESCRIPTION
예약 목록을 조회에서 상태 값이 **회고 작성 전**과 **회고 작성 후**에 따라 구별이 되어야 합니다.

사용자가 회고 작성 전에는 `RETROSPECTIVE_WAITING(2)` 상태에서 회고를 등록 했을 때 `RETROSPECTIVE_COMPLETE(3)` 변경하도록 개발을 진행했습니다.