### PR TITLE
24시간 내에 재로그인이 필요없도록 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
@@ -38,7 +38,7 @@ public class JwtUtil {
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setIssuer("fresh")
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(30).toMillis()))
+                .setExpiration(new Date(now.getTime() + Duration.ofMinutes(1440).toMillis()))
                 .claim("id", id)
                 .signWith(key)
                 .compact();


### PR DESCRIPTION
기존에는 토큰 유효기간이 30분이었습니다.
그래서 30분마다 재로그인을 해줘야 하는 불편함이 있었습니다.
따라서 토큰 유효기간을 24시간으로 늘렸습니다.