### PR TITLE
중복된 이메일로 회원가입을 할 수 없게 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -67,4 +67,10 @@ public class ControllerErrorAdvice {
     public String handleRetrospectiveNotFound() {
         return "회고 조회에 실패했습니다.";
     }
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(DuplicatedEmailException.class)
+    public String handleDuplicatedEmail() {
+        return "이미 가입된 이메일입니다. 다른 이메일로 회원 가입을 해주세요";
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
@@ -1,7 +1,9 @@
 package com.codesoom.myseat.controllers.signup;
 
 import com.codesoom.myseat.dto.SignupRequest;
+import com.codesoom.myseat.exceptions.DuplicatedEmailException;
 import com.codesoom.myseat.services.auth.SignupService;
+import com.codesoom.myseat.services.users.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -15,17 +17,21 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class SignupController {
     private final SignupService service;
+    private final UserService userService;
 
     public SignupController(
-            SignupService service
+            SignupService service,
+            UserService userService
     ) {
         this.service = service;
+        this.userService = userService;
     }
 
     /**
      * 회원 가입을 한다.
      * 
      * @param request 회원 가입 폼에 입력된 데이터
+     * @throws DuplicatedEmailException 이미 가입된 이메일로 회원 가입을 시도하면 던집니다.
      */
     @PostMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -35,9 +41,25 @@ public class SignupController {
         log.info("request: " + request.toString());
 
         String email = request.getEmail();
+        if(isDuplicatedEmail(email)) {
+            throw new DuplicatedEmailException();
+        }
+        
         String name = request.getName();
         String password = request.getPassword();
 
         service.createUser(name, email, password);
+    }
+
+    /**
+     * 이미 가입된 이메일이면 true, 그렇지 않으면 false를 반환합니다.
+     * 
+     * @param email 이메일
+     * @return 이미 가입된 이메일이면 true, 그렇지 않으면 false
+     */
+    public Boolean isDuplicatedEmail(
+            String email
+    ) {
+        return userService.existByEmail(email);
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
@@ -41,7 +41,7 @@ public class SignupController {
         log.info("request: " + request.toString());
 
         String email = request.getEmail();
-        if(isDuplicatedEmail(email)) {
+        if(userService.isDuplicatedEmail(email)) {
             throw new DuplicatedEmailException();
         }
         
@@ -49,17 +49,5 @@ public class SignupController {
         String password = request.getPassword();
 
         service.createUser(name, email, password);
-    }
-
-    /**
-     * 이미 가입된 이메일이면 true, 그렇지 않으면 false를 반환합니다.
-     * 
-     * @param email 이메일
-     * @return 이미 가입된 이메일이면 true, 그렇지 않으면 false
-     */
-    public Boolean isDuplicatedEmail(
-            String email
-    ) {
-        return userService.existByEmail(email);
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/DuplicatedEmailException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/DuplicatedEmailException.java
@@ -1,0 +1,15 @@
+package com.codesoom.myseat.exceptions;
+
+/** 이미 가입된 이메일로 회원 가입을 시도할 경우 발생하는 예외입니다. */
+public class DuplicatedEmailException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "이미 가입된 이메일입니다.";
+
+    public DuplicatedEmailException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public DuplicatedEmailException(String message) {
+        super(message);
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
@@ -34,4 +34,12 @@ public interface UserRepository
      * @return 조회된 회원 엔티티
      */
     Optional<User> findByEmail(String email);
+
+    /**
+     * 주어진 이메일로 회원 조회에 성공하면 true, 그렇지 않으면 false를 반환합니다.
+     * 
+     * @param email 이메일
+     * @return 회원 조회에 성공하면 true, 그렇지 않으면 false
+     */
+    Boolean existsByEmail(String email);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
@@ -47,4 +47,14 @@ public class UserService {
         return userRepo.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException());
     }
+
+    /**
+     * 주어진 이메일로 회원 조회에 성공하면 true, 그렇지 않으면 false를 반환합니다.
+     * 
+     * @param email 이메일
+     * @return 회원 조회에 성공하면 true, 그렇지 않으면 false
+     */
+    public Boolean existByEmail(String email) {
+        return userRepo.existsByEmail(email);
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
@@ -49,12 +49,12 @@ public class UserService {
     }
 
     /**
-     * 주어진 이메일로 회원 조회에 성공하면 true, 그렇지 않으면 false를 반환합니다.
-     * 
+     * 이미 가입된 이메일이면 true, 그렇지 않으면 false를 반환합니다.
+     *
      * @param email 이메일
-     * @return 회원 조회에 성공하면 true, 그렇지 않으면 false
+     * @return 이미 가입된 이메일이면 true, 그렇지 않으면 false
      */
-    public Boolean existByEmail(String email) {
+    public Boolean isDuplicatedEmail(String email) {
         return userRepo.existsByEmail(email);
     }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/signup/SignupControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/signup/SignupControllerTest.java
@@ -5,6 +5,7 @@ import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.SignupRequest;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.auth.SignupService;
+import com.codesoom.myseat.services.users.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +46,9 @@ class SignupControllerTest {
 
     @MockBean
     private SignupService signupService;
+    
+    @MockBean
+    private UserService userService;
 
     @MockBean
     private AuthenticationService authService;


### PR DESCRIPTION
기존에는 회원가입시 이메일 중복체크를 하지 않고 있었습니다.
따라서 같은 이메일로 회원가입을 여러번 할 수 있다는 문제가 있었습니다.
그래서 회원가입시 먼저 이메일 존재 여부를 확인하고, 이미 가입된 이메일이면 회원 가입을 할 수 없도록 했습니다.