### PR TITLE
회고 상세보기를 할 수 있게 하라

### DIFF
--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -1,5 +1,16 @@
 import * as React from 'react';
 
+import {
+  saveIsDetailRetrospectives,
+} from '../../redux/retrospectivesSlice';
+
+import {
+  saveIsDetail,
+  selectReservationId,
+} from '../../redux/reservationsSlice';
+
+import { useAppDispatch } from '../../hooks';
+
 import { styled } from '@mui/material/styles';
 
 import {
@@ -15,15 +26,13 @@ import {
   TableBody,
   TableFooter,
 } from '@mui/material';
-import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 
-import { saveIsDetail, selectReservationId } from '../../redux/reservationsSlice';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 
 import FirstPageIcon from '@mui/icons-material/FirstPage';
 import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 import LastPageIcon from '@mui/icons-material/LastPage';
-import { useAppDispatch } from '../../hooks';
 
 interface TablePaginationActionsProps {
   count: number;
@@ -32,7 +41,7 @@ interface TablePaginationActionsProps {
   onPageChange: (
     event: React.MouseEvent<HTMLButtonElement>,
     newPage: number,
-  ) => void;
+  )=> void;
 }
 
 const StyledTableCell = styled(TableCell)({
@@ -145,17 +154,29 @@ export default function ReservationsTable({
     dispatch(selectReservationId(id));
   };
 
-  const handleClickRetrospective = (e: React.MouseEvent<HTMLButtonElement>, id: number) => {
+  const handleClickRetrospective = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    id: number,
+    status: string,
+  ) => {
     onOpenRetrospectModal(e);
 
     dispatch(selectReservationId(id));
+
+    if (status === 'RETROSPECTIVE_WAITING') {
+      dispatch(saveIsDetailRetrospectives(true));
+    }
+
+    if (status === 'RETROSPECTIVE_WAITING') {
+      dispatch(saveIsDetailRetrospectives(false));
+    }
   };
 
   const statusName: StatusType = {
     'RESERVED': '예약완료',
     'CANCELED': '취소',
-    'RETROSPECTIVE_COMPLETE': '회고 제출하기',
-    'RETROSPECTIVE_WAITING': '회고 작성전',
+    'RETROSPECTIVE_COMPLETE': '회고 상세보기',
+    'RETROSPECTIVE_WAITING': '회고 작성',
   };
 
 
@@ -187,7 +208,7 @@ export default function ReservationsTable({
               <TableCell align="left">{content}</TableCell>
               <TableCell align="center">
                 <Button onClick={(e) => {
-                  handleClickRetrospective(e, id);
+                  handleClickRetrospective(e, id, status);
                 }}>
                   {statusName[status]}
                 </Button>

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -72,7 +72,7 @@ interface Props {
 }
 
 function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler }) {
-  const { id } = useAppSelector(get('reservations'));
+  const { id } = useAppSelector(get('retrospectives'));
 
   const { isLoading, data } = useQuery(
     retrospectivesKeys.retrospectivesById(id),

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -71,7 +71,7 @@ interface Props {
   onApply: React.ReactEventHandler,
 }
 
-function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler }) {
+function DetailReservationDialog({ onClose }: { onClose: React.ReactEventHandler }) {
   const { id } = useAppSelector(get('retrospectives'));
 
   const { isLoading, data } = useQuery(
@@ -85,7 +85,7 @@ function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler 
   return (
     <Wrap>
       <TextTitle>회고</TextTitle>
-      <TextBox>{data.content.split('\n').map((line:string) => (<p>{line}</p>))}</TextBox>
+      <TextBox>{data.content.split('\n').map((line: string) => (<p>{line}</p>))}</TextBox>
       <ButtonWrap>
         <Button variant="outlined" size="small" onClick={onClose}>
             취소
@@ -95,9 +95,9 @@ function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler 
   );
 }
 
-function ApplyReservationDialog({ onClose, onApply }:{
-  onClose : React.ReactEventHandler;
-  onApply : React.ReactEventHandler;
+function ApplyReservationDialog({ onClose, onApply }: {
+  onClose: React.ReactEventHandler;
+  onApply: React.ReactEventHandler;
 }) {
   const dispatch = useDispatch();
 

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -72,7 +72,7 @@ interface Props {
 }
 
 function DetailReservationDialog({ onClose }: { onClose: React.ReactEventHandler }) {
-  const { id } = useAppSelector(get('retrospectives'));
+  const { id } = useAppSelector(get('reservations'));
 
   const { isLoading, data } = useQuery(
     retrospectivesKeys.retrospectivesById(id),

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -1,13 +1,27 @@
 import { useDispatch } from 'react-redux';
 
-import styled from '@emotion/styled';
+import { useAppSelector } from '../../hooks';
 
-import { Button, Dialog, DialogTitle, TextField } from '@mui/material';
+import { get } from '../../utils';
 
 import { saveRetrospectives } from '../../redux/retrospectivesSlice';
 
-import { useAppSelector } from '../../hooks';
-import { get } from '../../utils';
+import { useQuery } from 'react-query';
+
+import {
+  getRetrospective,
+  retrospectivesKeys,
+} from '../../services/retrospectives';
+
+import styled from '@emotion/styled';
+
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  TextField }
+  from '@mui/material';
 
 const Wrap = styled.div({
   display: 'flex',
@@ -34,13 +48,57 @@ const Text = styled(TextField)({
   margin: '1rem 3rem 1rem 0',
 });
 
+const TextTitle = styled.h1({
+  marginBottom: '1rem',
+  fontSize: '1.3rem',
+});
+
+const TextBox = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  maxHeight: '20rem',
+  overflow: 'auto',
+  marginBottom: '2rem',
+
+  'p': {
+    margin: '0 0 1rem 0',
+  },
+});
+
 interface Props {
   open: boolean,
   onClose: React.ReactEventHandler,
   onApply: React.ReactEventHandler,
 }
 
-const RetrospectivesModal: React.FC<Props> = ({ open, onClose, onApply }: Props) => {
+function DetailReservationDialog({ onClose }:{ onClose: React.ReactEventHandler }) {
+  const { id } = useAppSelector(get('reservations'));
+
+  const { isLoading, data } = useQuery(
+    retrospectivesKeys.retrospectivesById(id),
+    () => getRetrospective(id), { retry: 1 });
+
+  if (isLoading) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <Wrap>
+      <TextTitle>회고</TextTitle>
+      <TextBox>{data.content.split('\n').map((line:string) => (<p>{line}</p>))}</TextBox>
+      <ButtonWrap>
+        <Button variant="outlined" size="small" onClick={onClose}>
+            취소
+        </Button>
+      </ButtonWrap>
+    </Wrap>
+  );
+}
+
+function ApplyReservationDialog({ onClose, onApply }:{
+  onClose : React.ReactEventHandler;
+  onApply : React.ReactEventHandler;
+}) {
   const dispatch = useDispatch();
 
   const { retrospectives } = useAppSelector(get('retrospectives'));
@@ -55,14 +113,10 @@ const RetrospectivesModal: React.FC<Props> = ({ open, onClose, onApply }: Props)
   };
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-    >
+    <>
       <Title>
-        회고 작성하기
+          회고 작성하기
       </Title>
-
       <Wrap>
         <Text
           inputProps={{ maxLength: characterMaximum, minLength: characterMinimum }}
@@ -77,19 +131,35 @@ const RetrospectivesModal: React.FC<Props> = ({ open, onClose, onApply }: Props)
         />
         <ButtonWrap>
           <Button variant='outlined' size='small' onClick={onClose}>
-            취소
+              취소
           </Button>
           <Button
             variant='contained' size='small'
             disabled={!isMinimum}
             onClick={onApply}
           >
-            제출
+              제출
           </Button>
         </ButtonWrap>
       </Wrap >
+    </>
+  );
+}
+
+
+
+export default function ReservationDialog({ open, onClose, onApply }: Props) {
+  const { isDetail } = useAppSelector(get('retrospectives'));
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="form-dialog-title"
+    >
+      {isDetail
+        ? <DetailReservationDialog onClose={onClose} />
+        : <ApplyReservationDialog onClose={onClose} onApply={onApply} />}
     </Dialog >
   );
-};
-
-export default RetrospectivesModal;
+}

--- a/app-web/src/redux/retrospectivesSlice.tsx
+++ b/app-web/src/redux/retrospectivesSlice.tsx
@@ -2,11 +2,13 @@ import { createSlice } from '@reduxjs/toolkit';
 
 interface RetrospectivesState {
   isOpenRetrospectModal: boolean,
+  isDetail: boolean,
   retrospectives: string,
 }
 
 const initialState: RetrospectivesState = {
   isOpenRetrospectModal: false,
+  isDetail: false,
   retrospectives: '',
 };
 
@@ -28,13 +30,18 @@ const { reducer, actions } = createSlice({
       ...state,
       retrospectives: initialState.retrospectives,
     }),
+    saveIsDetailRetrospectives: (state, { payload }) => ({
+      ...state,
+      isDetail: payload,
+    }),
   },
 });
 
 export const {
-  toggleRetrospectModal,
-  saveRetrospectives,
   resetRetrospectives,
+  saveRetrospectives,
+  saveIsDetailRetrospectives,
+  toggleRetrospectModal,
 } = actions;
 
 export default reducer;

--- a/app-web/src/services/retrospectives.ts
+++ b/app-web/src/services/retrospectives.ts
@@ -20,10 +20,10 @@ export const fetchRetrospectives = ({ id, content }: { id: number, content: stri
 };
 
 export const retrospectivesKeys = {
-  retrospectivesById: (id : number) => ['retrospectives', id] as const,
+  retrospectivesById: (id: number) => ['retrospectives', id] as const,
 };
 
-export const getRetrospective = async (id : number) => {
+export const getRetrospective = async (id: number) => {
   const accessToken = loadItem('accessToken');
   const { data } = await api({
     method: 'get',

--- a/app-web/src/services/retrospectives.ts
+++ b/app-web/src/services/retrospectives.ts
@@ -18,3 +18,18 @@ export const fetchRetrospectives = ({ id, content }: { id: number, content: stri
     data: { content },
   });
 };
+
+export const retrospectivesKeys = {
+  retrospectivesById: (id : number) => ['retrospectives', id] as const,
+};
+
+export const getRetrospective = async (id : number) => {
+  const accessToken = loadItem('accessToken');
+  const { data } = await api({
+    method: 'get',
+    url: `reservations/${id}/retrospectives`,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return data;
+};


### PR DESCRIPTION
회고 상세보기 api작업을 진행하고
회고를 작성했을 시, 회고 상세보기 버튼이 렌더링되고
회고를 작성 안했을 시, 회고 작성 버튼이 렌더링됩니다.

회고 작성을 누르면 회고 작성 모달이 렌더링되고 회고를 작성할 수 있습니다.

회고 상세보기 버튼을 누르면 회고 상세보기 모달이 렌더링되고 회고를 볼 수 있습니다.