### PR TITLE
한 예약에 대해 회고를 두번 작성할 수 없도록 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -73,4 +73,10 @@ public class ControllerErrorAdvice {
     public String handleDuplicatedEmail() {
         return "이미 가입된 이메일입니다. 다른 이메일로 회원 가입을 해주세요";
     }
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(AlreadyPostedRetrospectiveException.class)
+    public String handleAlreadyPostedRetrospective() {
+        return "이미 회고를 작성했습니다.";
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 
-import java.util.Objects;
-
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -66,4 +64,12 @@ public class Reservation {
         this.plan.update(updateData.getContent());
     }
 
+    /**
+     * 회고가 null이 아니면 true, 그렇지 않으면 false를 반환합니다.
+     * 
+     * @return 회고가 null이면 true, 그렇지 않으면 false
+     */
+    public boolean haveRetrospective() {
+        return this.retrospective != null;
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/AlreadyPostedRetrospectiveException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/AlreadyPostedRetrospectiveException.java
@@ -1,0 +1,8 @@
+package com.codesoom.myseat.exceptions;
+
+/** 이미 회고를 작성했던 예약에 대해 회고 작성을 시도하면 발생하는 예외입니다.*/
+public class AlreadyPostedRetrospectiveException extends RuntimeException {
+    public AlreadyPostedRetrospectiveException() {
+        super();
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
@@ -62,4 +62,12 @@ public interface ReservationRepository
      * @return 예약한 회원이면 true, 그렇지 않으면 false
      */
     boolean existsByIdAndUser_Id(Long id, Long userId);
+
+    /**
+     * 주어진 예약 id로 조회된 예약을 반환합니다.
+     * 
+     * @param id must not be {@literal null}. 예약 id
+     * @return 조회된 예약
+     */
+    Optional<Reservation> findById(Long id);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationService.java
@@ -4,6 +4,7 @@ import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.PlanRepository;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -72,5 +73,17 @@ public class ReservationService {
      */
     public boolean isDuplicateReservation(String date, Long id) {
         return reservationRepo.existsByDateAndUser_Id(date, id);
+    }
+
+    /**
+     * 주어진 id로 조회된 예약을 반환합니다.
+     * 
+     * @param id 예약 id
+     * @return 조회된 예약
+     * @throws ReservationNotFoundException 예약 조회에 실패하면 던집니다.
+     */
+    public Reservation findReservation(Long id) {
+        return reservationRepo.findById(id)
+                .orElseThrow(() -> new ReservationNotFoundException());
     }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveControllerTest.java
@@ -1,9 +1,12 @@
 package com.codesoom.myseat.controllers.reservations.retrospectives;
 
 import com.codesoom.myseat.controllers.reservations.retrospectives.RetrospectiveController;
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.RetrospectiveRequest;
 import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationService;
 import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveService;
 import com.codesoom.myseat.services.users.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -41,6 +44,9 @@ class RetrospectiveControllerTest {
 
     @MockBean
     private RetrospectiveService retrospectiveService;
+    
+    @MockBean
+    private ReservationService reservationService;
 
     @MockBean
     private UserService userService;
@@ -54,12 +60,26 @@ class RetrospectiveControllerTest {
                 .email("soo@email.com")
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
                 .build();
+        
+        Plan mockPlan = Plan.builder()
+                .id(2L)
+                .content("밥먹기, 코테풀기")
+                .build();
+        
+        Reservation mockReservation = Reservation.builder()
+                .id(3L)
+                .user(mockUser)
+                .plan(mockPlan)
+                .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
                 .willReturn(1L);
 
         given(userService.findById(1L))
                 .willReturn(mockUser);
+
+        given(reservationService.findReservation(1L))
+                .willReturn(mockReservation);
 
         RetrospectiveRequest request = RetrospectiveRequest.builder()
                 .content("잘했다.")


### PR DESCRIPTION
기존에는 회고 작성시 해당 예약에 대한 회고가 이미 존재하는지 확인하지 않고 있었습니다.
그래서 한 예약에 대해 회고를 여러번 작성할 수 있었습니다.
따라서 회고 작성을 요청한 예약에 대해 회고의 존재 여부를 확인하는 로직을 추가했습니다.