### PR TITLE
예약 수정 시 날짜 중복 예약을 제한하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -2,6 +2,7 @@ package com.codesoom.myseat.services.reservations;
 
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
@@ -26,6 +27,7 @@ public class ReservationUpdateService {
      * @param request 수정 데이터
      * @throws ReservationNotFoundException 주어진 예약 id로 예약을 찾지 못한 경우
      * @throws NotOwnedReservationException 요청한 회원 소유의 예약이 아닌 경우
+     * @throws AlreadyReservedException 수정하려는 날짜에 예약한 기록이 이미 있는 경우
      */
     @Transactional
     public void updateReservation(Long userId, Long id, ReservationRequest request) {
@@ -34,7 +36,21 @@ public class ReservationUpdateService {
         if (!reservation.isOwnReservation(userId)) {
             throw new NotOwnedReservationException();
         }
+        if (hasSameDateReservation(request.getDate(), userId)) {
+            throw new AlreadyReservedException();
+        }
         reservation.update(request);
+    }
+
+    /**
+     * 동일한 날짜에 예약한 기록의 유무를 반환합니다.
+     *
+     * @param date 예약 날짜
+     * @param userId 회원 id
+     * @return 기록이 있으면 true, 없으면 false
+     */
+    private boolean hasSameDateReservation(String date, Long userId) {
+        return repository.existsByDateAndUser_Id(date, userId);
     }
 
 }


### PR DESCRIPTION
현재 예약 수정 시 날짜도 수정할 수 있습니다.
이 때 이미 예약이 등록된 날짜로 수정할 경우 수정을 제한하는 기능을 추가했습니다.