### PR TITLE
예약 수정 시 날짜를 변경한 경우에만 중복 검사를 수행하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -81,4 +81,14 @@ public class Reservation {
         this.status = ReservationStatus.RETROSPECTIVE_COMPLETE;
     }
 
+    /**
+     * 예약의 날짜와 주어진 날짜가 다른지 확인합니다.
+     *
+     * @param date 비교하려는 날짜
+     * @return 원래 날짜와 주어진 날짜가 다르면 true, 같으면 false
+     */
+    public boolean isDifferentDate(String date) {
+        return !this.date.equals(date);
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -36,16 +36,12 @@ public class ReservationUpdateService {
         if (!reservation.isOwnReservation(userId)) {
             throw new NotOwnedReservationException();
         }
-        if (isChangeDate(reservation.getDate(), reservation.getDate())) {
+        if (reservation.isDifferentDate(reservation.getDate())) {
             if (hasSameDateReservation(request.getDate(), userId)) {
                 throw new AlreadyReservedException();
             }
         }
         reservation.update(request);
-    }
-
-    private boolean isChangeDate(String originDate, String newDate) {
-        return !originDate.equals(newDate);
     }
 
     /**

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -36,10 +36,16 @@ public class ReservationUpdateService {
         if (!reservation.isOwnReservation(userId)) {
             throw new NotOwnedReservationException();
         }
-        if (hasSameDateReservation(request.getDate(), userId)) {
-            throw new AlreadyReservedException();
+        if (isChangeDate(reservation.getDate(), reservation.getDate())) {
+            if (hasSameDateReservation(request.getDate(), userId)) {
+                throw new AlreadyReservedException();
+            }
         }
         reservation.update(request);
+    }
+
+    private boolean isChangeDate(String originDate, String newDate) {
+        return !originDate.equals(newDate);
     }
 
     /**


### PR DESCRIPTION
예약 수정 시 날짜와 계획을 수정할 수 있습니다.

기존 코드는 날짜를 수정하지 않은 경우에도 해당 날짜에 이미 예약이 있는지 확인하고 있었습니다.
그래서 계획만 수정하는 경우에 중복 예약으로 간주되는 문제가 있습니다.

예약 날짜를 수정하는 경우에만 중복 검사를 하도록 변경했습니다.