### PR TITLE
예약 취소 시 취소상태로 변경되게 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationCancelService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationCancelService.java
@@ -35,6 +35,7 @@ public class ReservationCancelService {
             throw new NotOwnedReservationException();
         }
         reservation.cancel();
+        repository.save(reservation);
     }
 
 }


### PR DESCRIPTION
현재 취소 요청 후에 상태가 제대로 변경되지 않는 문제가 있었습니다.

예약의 상태를 `CANCELED`로 변경한 후 바로 데이터베이스에 반영되도록 `save()`를 사용했습니다.