### PR TITLE
회고를 수정 하라

### DIFF
--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -186,6 +186,8 @@ export default function ReservationsTable({
     if (status === 'RETROSPECTIVE_WAITING') {
       dispatch(saveIsDetailRetrospectives(false));
     }
+
+    dispatch(saveIsUpdateRetrospectives(false));
   };
 
   const statusName: StatusType = {

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { saveIsDetailRetrospectives } from '../../redux/retrospectivesSlice';
+import { saveIsDetailRetrospectives, saveIsUpdateRetrospectives } from '../../redux/retrospectivesSlice';
 
 import { saveIsDetail, selectReservationId } from '../../redux/reservationsSlice';
 
@@ -176,6 +176,8 @@ export default function ReservationsTable({
     onOpenRetrospectModal(e);
 
     dispatch(selectReservationId(id));
+
+    dispatch(saveIsUpdateRetrospectives(false));
 
     if (status === 'RETROSPECTIVE_COMPLETE') {
       dispatch(saveIsDetailRetrospectives(true));

--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -186,8 +186,6 @@ export default function ReservationsTable({
     if (status === 'RETROSPECTIVE_WAITING') {
       dispatch(saveIsDetailRetrospectives(false));
     }
-
-    dispatch(saveIsUpdateRetrospectives(false));
   };
 
   const statusName: StatusType = {

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -16,7 +16,7 @@ import ReservationsTable from '../components/reservations/ReservationsTable';
 import RetrospectivesModal from './Retrospectives';
 
 import { fetchReservation, getReservation, updateReservation } from '../services/reservations';
-import { fetchRetrospectives } from '../services/retrospectives';
+import { fetchRetrospectives, updateRetrospectives } from '../services/retrospectives';
 
 const Container = styled.div({
   display: 'flex',
@@ -124,6 +124,23 @@ export default function Reservations() {
     });
   };
 
+  const { mutate: updateRetrospectiveMutate } = useMutation(updateRetrospectives, {
+    onSuccess: () => {
+      alert('회고가 수정되었습니다.');
+      onClickToggleRetrospectModal();
+    },
+    onError: () => {
+      alert('회고 수정에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
+
+  const onClickUpdateRetrospectives = () => {
+    updateRetrospectiveMutate({
+      id,
+      content: retrospectives,
+    });
+  };
+
   const { isLoading, data, isError } = useQuery('reservations', getReservation, {
     retry: 1,
   });
@@ -143,6 +160,7 @@ export default function Reservations() {
         open={isOpenRetrospectModal}
         onClose={onClickToggleRetrospectModal}
         onApply={onClickApplyRetrospectives}
+        onUpdate={onClickUpdateRetrospectives}
       />
 
       <Wrap>

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -1,8 +1,8 @@
-import { useDispatch } from 'react-redux';
+import {useDispatch} from 'react-redux';
 
-import { useAppSelector } from '../../hooks';
+import {useAppSelector} from '../../hooks';
 
-import { get } from '../../utils';
+import {get} from '../../utils';
 
 import {
   saveIsDetailRetrospectives,
@@ -10,13 +10,13 @@ import {
   saveRetrospectives,
 } from '../../redux/retrospectivesSlice';
 
-import { useQuery } from 'react-query';
+import {useQuery} from 'react-query';
 
-import { getRetrospective, retrospectivesKeys } from '../../services/retrospectives';
+import {getRetrospective, retrospectivesKeys} from '../../services/retrospectives';
 
 import styled from '@emotion/styled';
 
-import { Button, CircularProgress, Dialog, DialogTitle, TextField } from '@mui/material';
+import {Button, CircularProgress, Dialog, DialogTitle, TextField} from '@mui/material';
 
 const Wrap = styled.div({
   display: 'flex',
@@ -72,7 +72,7 @@ function DetailRetrospectivesDialog({ onClose }: { onClose: React.ReactEventHand
 
   const { id } = useAppSelector(get('reservations'));
 
-  const { isLoading, data } = useQuery(
+  const { isLoading, data :{content}} = useQuery(
     retrospectivesKeys.retrospectivesById(id),
     () => getRetrospective(id), {
       onSuccess: (response) => {
@@ -93,7 +93,7 @@ function DetailRetrospectivesDialog({ onClose }: { onClose: React.ReactEventHand
   return (
     <Wrap>
       <TextTitle>회고</TextTitle>
-      <TextBox>{data.content.split('\n').map((line: string) => (<p key={id}>{line}</p>))}</TextBox>
+      <TextBox>{content.split('\n').map((line: string) => (<p key={id}>{line}</p>))}</TextBox>
       <ButtonWrap>
         <Button variant="outlined" size="small" onClick={onClose}>
           취소
@@ -142,7 +142,11 @@ function ApplyRetrospectivesDialog({ onClose, onApply, onUpdate }: {
           rows={3}
         />
         <ButtonWrap>
-          <Button variant='outlined' size='small' onClick={onClose}>
+          <Button
+            variant='outlined'
+            size='small'
+            onClick={onClose}
+          >
             취소
           </Button>
           {isUpdate

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -1,8 +1,8 @@
-import {useDispatch} from 'react-redux';
+import { useDispatch } from 'react-redux';
 
-import {useAppSelector} from '../../hooks';
+import { useAppSelector } from '../../hooks';
 
-import {get} from '../../utils';
+import { get } from '../../utils';
 
 import {
   saveIsDetailRetrospectives,
@@ -10,13 +10,13 @@ import {
   saveRetrospectives,
 } from '../../redux/retrospectivesSlice';
 
-import {useQuery} from 'react-query';
+import { useQuery } from 'react-query';
 
-import {getRetrospective, retrospectivesKeys} from '../../services/retrospectives';
+import { getRetrospective, retrospectivesKeys } from '../../services/retrospectives';
 
 import styled from '@emotion/styled';
 
-import {Button, CircularProgress, Dialog, DialogTitle, TextField} from '@mui/material';
+import { Button, CircularProgress, Dialog, DialogTitle, TextField } from '@mui/material';
 
 const Wrap = styled.div({
   display: 'flex',
@@ -72,7 +72,7 @@ function DetailRetrospectivesDialog({ onClose }: { onClose: React.ReactEventHand
 
   const { id } = useAppSelector(get('reservations'));
 
-  const { isLoading, data :{content}} = useQuery(
+  const { isLoading, data: { content } } = useQuery(
     retrospectivesKeys.retrospectivesById(id),
     () => getRetrospective(id), {
       onSuccess: (response) => {

--- a/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
+++ b/app-web/src/pages/Retrospectives/RetrospectivesModal.tsx
@@ -72,7 +72,7 @@ function DetailRetrospectivesDialog({ onClose }: { onClose: React.ReactEventHand
 
   const { id } = useAppSelector(get('reservations'));
 
-  const { isLoading, data: { content } } = useQuery(
+  const { isLoading, data } = useQuery(
     retrospectivesKeys.retrospectivesById(id),
     () => getRetrospective(id), {
       onSuccess: (response) => {
@@ -89,6 +89,8 @@ function DetailRetrospectivesDialog({ onClose }: { onClose: React.ReactEventHand
   if (isLoading) {
     return <CircularProgress />;
   }
+
+  const { content } = data;
 
   return (
     <Wrap>

--- a/app-web/src/redux/retrospectivesSlice.tsx
+++ b/app-web/src/redux/retrospectivesSlice.tsx
@@ -3,12 +3,14 @@ import { createSlice } from '@reduxjs/toolkit';
 interface RetrospectivesState {
   isOpenRetrospectModal: boolean,
   isDetail: boolean,
+  isUpdate: boolean,
   retrospectives: string,
 }
 
 const initialState: RetrospectivesState = {
   isOpenRetrospectModal: false,
   isDetail: false,
+  isUpdate: false,
   retrospectives: '',
 };
 
@@ -34,6 +36,10 @@ const { reducer, actions } = createSlice({
       ...state,
       isDetail: payload,
     }),
+    saveIsUpdateRetrospectives: (state, { payload }) => ({
+      ...state,
+      isUpdate: payload,
+    }),
   },
 });
 
@@ -41,6 +47,7 @@ export const {
   resetRetrospectives,
   saveRetrospectives,
   saveIsDetailRetrospectives,
+  saveIsUpdateRetrospectives,
   toggleRetrospectModal,
 } = actions;
 

--- a/app-web/src/services/retrospectives.ts
+++ b/app-web/src/services/retrospectives.ts
@@ -33,3 +33,13 @@ export const getRetrospective = async (id: number) => {
 
   return data;
 };
+
+export const updateRetrospectives = ({ id, content }: { id: number, content: string }) => {
+  const accessToken = loadItem('accessToken');
+
+  return api.put(`/reservations/${id}/retrospectives`, { content }, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};


### PR DESCRIPTION
회고 수정 기능작업을 했습니다.
회고 상세보기 화면에 수정버튼을 누르면 작성 모달로 변환됩니다.
수정버튼을 누르면 수정상태가 됩니다.
수정상태인 상태로 작성 모달에서 제출을 누르면 수정 api를 호출합니다.

모달을 랜더할 때에 isDetail isEdit 등 flag를 사용하여 랜더링 하고 있습니다. 모달 랜더에 필요한 flag 사용을 없애는 티켓을 만들었습니다.
현재 회고 내용을 retrospectives로 쓰고있습니다.  백엔드와 동일한 content로 변경이 필요합니다 티켓을 만들었습니다

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/30693333/197169511-c8e5b82b-f307-4c6b-8312-a63d296d2e85.gif)
