### PR TITLE
회고 수정 API를 작성하라.

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
@@ -1,0 +1,48 @@
+package com.codesoom.myseat.controllers.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.RetrospectiveRequest;
+import com.codesoom.myseat.security.UserAuthentication;
+import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveUpdateService;
+import com.codesoom.myseat.services.users.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin
+@RestController
+@RequestMapping("/reservations")
+@Slf4j
+public class RetrospectiveUpdateController {
+
+    private final RetrospectiveUpdateService retrospectiveUpdateService;
+    private final UserService userService;
+
+    public RetrospectiveUpdateController(RetrospectiveUpdateService retrospectiveUpdateService, UserService userService) {
+        this.retrospectiveUpdateService = retrospectiveUpdateService;
+        this.userService = userService;
+    }
+
+    @PutMapping("/{id}/retrospectives")
+    @PreAuthorize("isAuthenticated()")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateRetrospective(
+            @AuthenticationPrincipal final UserAuthentication principal,
+            @PathVariable("id") final Long id,
+            @RequestBody final RetrospectiveRequest request
+    ) {
+
+        User user = userService.findById(principal.getId());
+        String content = request.getContent();
+
+        retrospectiveUpdateService.updateRetrospective(id, user, content);
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
@@ -35,4 +35,7 @@ public class Retrospective {
     @JoinColumn(name = "reservation_id")
     private Reservation reservation;
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
@@ -1,0 +1,50 @@
+package com.codesoom.myseat.services.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.RetrospectiveNotFoundException;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import com.codesoom.myseat.repositories.RetrospectiveRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+public class RetrospectiveUpdateService {
+
+    private final RetrospectiveRepository retrospectiveRepository;
+    private final ReservationRepository reservationRepository;
+
+    public RetrospectiveUpdateService(RetrospectiveRepository retrospectiveRepository, ReservationRepository reservationRepository) {
+        this.retrospectiveRepository = retrospectiveRepository;
+        this.reservationRepository = reservationRepository;
+    }
+
+    /**
+     * 회고 내용을 수정합니다.
+     *
+     * @param reservationId 예약 Id
+     * @param user 회원
+     * @param content 수정 할 회고 내용
+     * @throws NotOwnedReservationException 요청한 회원이 해당 예약에 대해 회고를 작성하는 경우
+     * @throws RetrospectiveNotFoundException 회고 Id를 찾지 못한 경우
+     */
+    @Transactional
+    public Retrospective updateRetrospective(final Long reservationId,
+                                             final User user,
+                                             final String content) {
+        Reservation reservation = reservationRepository.findByIdAndUser_Id(reservationId, user.getId())
+                .orElseThrow(NotOwnedReservationException::new);
+
+        Retrospective retrospective = retrospectiveRepository.findByReservationId(reservation.getId())
+                .orElseThrow(RetrospectiveNotFoundException::new);
+
+        retrospective.updateContent(content);
+
+        return retrospective;
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateControllerTest.java
@@ -1,0 +1,128 @@
+package com.codesoom.myseat.controllers.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.RetrospectiveRequest;
+import com.codesoom.myseat.exceptions.RetrospectiveNotFoundException;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationService;
+import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveUpdateService;
+import com.codesoom.myseat.services.users.UserService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RetrospectiveUpdateController.class)
+class RetrospectiveUpdateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private ReservationService reservationService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private RetrospectiveUpdateService retrospectiveUpdateService;
+
+    private User mockUser;
+    private Reservation mockReservation;
+    private Plan mockPlan;
+    private Retrospective mockRetrospective;
+
+    @BeforeEach
+    public void setUp() {
+        mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        mockPlan = Plan.builder()
+                .id(1L)
+                .content("밥먹기, 코테풀기")
+                .build();
+
+        mockReservation = Reservation.builder()
+                .id(1L)
+                .user(mockUser)
+                .plan(mockPlan)
+                .build();
+
+        mockRetrospective.builder()
+                .id(1L)
+                .content("잘했다.")
+                .reservation(mockReservation)
+                .build();
+
+        given(userService.findById(1L)).willReturn(mockUser);
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn(1L);
+
+        given(reservationService.findReservation(1L))
+                .willReturn(mockReservation);
+
+    }
+
+    @Test
+    @DisplayName("Put /reservations/{id}/retrospectives 요청 시 상태코드 204를 응답한다")
+    void put_retrospectiveDto_returns_retrospective_and_responses_status_code_204() throws Exception {
+        RetrospectiveRequest request = new RetrospectiveRequest("수정했다.");
+
+        mockMvc.perform(put("/reservations/1/retrospectives")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .content(toJson(request)))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("예약자 Id를 찾지 못한 경우 403 에러를 응답한다.")
+    void If_Not_Found_RetrospectiveId_responses_status_code_400() throws Exception {
+        RetrospectiveRequest request = new RetrospectiveRequest("수정했다.");
+
+        given(retrospectiveUpdateService.updateRetrospective(1000L,  mockUser, "수정했다."))
+                .willThrow(new RetrospectiveNotFoundException());
+
+        mockMvc.perform(put("/reservations/1000/retrospectives")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isForbidden())
+                .andDo(print());
+    }
+
+    private String toJson(
+            Object object
+    ) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(object);
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateServiceTest.java
@@ -1,0 +1,95 @@
+package com.codesoom.myseat.services.reservations.retrospectives;
+
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Retrospective;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.RetrospectiveNotFoundException;
+import com.codesoom.myseat.repositories.ReservationRepository;
+import com.codesoom.myseat.repositories.RetrospectiveRepository;
+import com.codesoom.myseat.repositories.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+class RetrospectiveUpdateServiceTest {
+
+    private RetrospectiveUpdateService service;
+
+    @Mock
+    private RetrospectiveRepository retrospectiveRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User mockUser;
+    private Reservation mockReservation;
+    private Retrospective mockRetrospective;
+
+    private final Long USER_ID = 1L;
+    private final Long RETROSPECTIVE_ID = 1L;
+    private final Long RESERVATION_ID = 1L;
+
+    private final Long ANOTHER_RETROSPECTIVE_ID = 1000L;
+    private final Long ANOTHER_RESERVATION_ID = 1000L;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        service = new RetrospectiveUpdateService(retrospectiveRepository, reservationRepository);
+
+        mockUser = User.builder()
+                .id(USER_ID)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        mockReservation = Reservation.builder()
+                .id(RESERVATION_ID)
+                .user(mockUser)
+                .build();
+
+        mockRetrospective = Retrospective.builder()
+                .id(RETROSPECTIVE_ID)
+                .content("잘했다.")
+                .reservation(mockReservation)
+                .build();
+
+        given(reservationRepository.findByIdAndUser_Id(RESERVATION_ID,USER_ID)).willReturn(Optional.of(mockReservation));
+
+        given(retrospectiveRepository.findByReservationId(RESERVATION_ID)).willReturn(Optional.of(mockRetrospective));
+
+        given(retrospectiveRepository.findByReservationId(ANOTHER_RETROSPECTIVE_ID))
+                .willThrow(new RetrospectiveNotFoundException());
+    }
+
+    @Test
+    @DisplayName("updateRetrospective 메서드는 retrospective을 반환한다.")
+    void updateRetrospective_will_return_retrospective() {
+        Retrospective retrospective = service.updateRetrospective(RESERVATION_ID, mockUser, "수정했다.");
+
+        assertThat(retrospective.getContent()).isEqualTo("수정했다.");
+        assertThat(retrospective.getId()).isEqualTo(RETROSPECTIVE_ID);
+        assertThat(retrospective.getReservation().getId()).isEqualTo(RESERVATION_ID);
+    }
+
+    @Test
+    @DisplayName("예약자가 아닌 회원이 해당 예약에 대해 회고를 작성하려고 NotOwnedReservationException 예외를 던진다.")
+    void NotFound_RetrospectiveId_will_throw_RetrospectiveNotFoundException() {
+        assertThatThrownBy(() -> service.updateRetrospective(ANOTHER_RESERVATION_ID, mockUser, "수정했다."))
+                .isInstanceOf(NotOwnedReservationException.class);
+    }
+
+}

--- a/app-server/http-request/local/회고수정.http
+++ b/app-server/http-request/local/회고수정.http
@@ -1,0 +1,7 @@
+PUT http://localhost:8080/reservations/1/retrospectives/1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer
+
+{
+  "content" : "아쉽다."
+}


### PR DESCRIPTION
회고 수정 API를 구현했습니다.

수정할 내용을 입력을 하면 이미 등록된 예약 Id와 회고 Id가 일치하면 수정 할 수 있습니다.

회원과 예약이 일치하지 않으면 소유하지 않은 예약이라고 에러가 발생합니다.
회고와 예약이 동일하지 않으면 회고를 수정 할 수 없는 에러가 발생합니다.
