### PR TITLE
회고와 계획의 글자수를 제한하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -79,4 +79,16 @@ public class ControllerErrorAdvice {
     public String handleAlreadyPostedRetrospective() {
         return "이미 회고를 작성했습니다.";
     }
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ContentTooLongException.class)
+    public String handleContentTooLong() {
+        return "입력값 길이가 너무 깁니다. 1000자 이하로 입력해주세요.";
+    }
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ContentTooShortException.class)
+    public String handleContentTooShort() {
+        return "입력값 길이가 너무 짧습니다. 100자 이상으로  입력해주세요.";
+    }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationController.java
@@ -3,6 +3,7 @@ package com.codesoom.myseat.controllers.reservations;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
+import com.codesoom.myseat.exceptions.ContentTooLongException;
 import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.reservations.ReservationService;
 import com.codesoom.myseat.services.users.UserService;
@@ -36,6 +37,7 @@ public class ReservationController {
      * 
      * @param request 예약 폼에 입력된 데이터
      * @throws AlreadyReservedException 방문 일자에 대한 예약 내역이 이미 존재하면 던집니다.
+     * @throws ContentTooLongException 계획의 길이가 너무 길면 던집니다.
      */
     @PostMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveController.java
@@ -4,6 +4,8 @@ import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.RetrospectiveRequest;
 import com.codesoom.myseat.exceptions.AlreadyPostedRetrospectiveException;
+import com.codesoom.myseat.exceptions.ContentTooLongException;
+import com.codesoom.myseat.exceptions.ContentTooShortException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.security.UserAuthentication;
@@ -45,6 +47,8 @@ public class RetrospectiveController {
      * @param request 회고 폼에 입력된 데이터
      * @throws NotOwnedReservationException 예약자가 아닌 회원이 해당 예약에 대해 회고를 작성하려고 한다면 예외를 던집니다.
      * @throws ReservationNotFoundException 예약 조회에 실패하면 던집니다.
+     * @throws ContentTooShortException 회고의 길이가 너무 짧을 경우 던집니다.
+     * @throws ContentTooLongException 회고의 길이가 너무 길면 던집니다.
      */
     @PostMapping("/{id}/retrospectives")
     @PreAuthorize("isAuthenticated()")
@@ -63,6 +67,9 @@ public class RetrospectiveController {
         
         String content = request.getContent();
         log.info("회고 요청: " + content);
+        if(content.length() < 100) {
+            throw new ContentTooShortException();
+        }
 
         retrospectiveService.createRetrospective(user, id, content);
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
@@ -25,6 +25,7 @@ public class Plan {
     @Column(name="plan_id")
     private Long id;
 
+    @Column(length = 1000)
     private String content;
 
     public void update(String content) {

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
@@ -28,6 +28,7 @@ public class Retrospective {
     @Column(name = "retrospective_id")
     private Long id;
 
+    @Column(length = 1000)
     private String content;
 
     @OneToOne(cascade = PERSIST)

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/ContentTooLongException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/ContentTooLongException.java
@@ -1,0 +1,8 @@
+package com.codesoom.myseat.exceptions;
+
+/** 입력한 데이터의 길이가 너무 길 경우 발생하는 예외입니다. */
+public class ContentTooLongException extends RuntimeException {
+    public ContentTooLongException() {
+        super();
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/ContentTooShortException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/ContentTooShortException.java
@@ -1,0 +1,8 @@
+package com.codesoom.myseat.exceptions;
+
+/** 입력한 데이터의 길이가 너무 짧을 경우 발생하는 예외입니다. */
+public class ContentTooShortException extends RuntimeException {
+    public ContentTooShortException() {
+        super();
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationService.java
@@ -4,10 +4,12 @@ import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
+import com.codesoom.myseat.exceptions.ContentTooLongException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.PlanRepository;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -37,6 +39,7 @@ public class ReservationService {
      * @param content 계획 내용
      * @return 생성된 예약
      * @throws AlreadyReservedException 방문 일자에 대한 예약 내역이 이미 존재하면 던집니다.
+     * @throws ContentTooLongException 계획의 길이가 너무 길면 던집니다.
      */
     @Transactional
     public Reservation createReservation(
@@ -58,7 +61,12 @@ public class ReservationService {
                 .plan(plan)
                 .build();
 
-        planRepo.save(plan);
+        try {
+            planRepo.save(plan);
+        } catch (InvalidDataAccessResourceUsageException e) {
+            e.printStackTrace();
+            throw new ContentTooLongException();
+        }
         reservationRepo.save(reservation);
 
         return reservation;

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveService.java
@@ -3,11 +3,13 @@ package com.codesoom.myseat.services.reservations.retrospectives;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.Retrospective;
 import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.exceptions.ContentTooLongException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import com.codesoom.myseat.repositories.RetrospectiveRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,6 +32,7 @@ public class RetrospectiveService {
      * @param content 회고 내용
      * @return 생성된 회고
      * @throws NotOwnedReservationException 예약자가 아닌 회원이 해당 예약에 대해 회고를 작성하려고 한다면 예외를 던집니다.
+     * @throws ContentTooLongException 회고의 길이가 너무 길면 던집니다.
      */
     public Retrospective createRetrospective(final User user,
                                              final Long reservationId,
@@ -51,7 +54,12 @@ public class RetrospectiveService {
 
         log.info("회고 요청: " + retrospective.getContent());
 
-        return retrospectiveRepository.save(retrospective);
+        try {
+            return retrospectiveRepository.save(retrospective);
+        } catch (InvalidDataAccessResourceUsageException e) {
+            e.printStackTrace();
+            throw new ContentTooLongException();
+        }
     }
 
     /**

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveControllerTest.java
@@ -1,6 +1,5 @@
 package com.codesoom.myseat.controllers.reservations.retrospectives;
 
-import com.codesoom.myseat.controllers.reservations.retrospectives.RetrospectiveController;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
@@ -82,7 +81,9 @@ class RetrospectiveControllerTest {
                 .willReturn(mockReservation);
 
         RetrospectiveRequest request = RetrospectiveRequest.builder()
-                .content("잘했다.")
+                .content("상호작용의 첫 단계는 사용자로부터 시작합니다. \n" +
+                        "직관적인 입력을 제공하여 사용하기 쉬운 편안한 환경을 사용자에게 제공해 줄 수 있습니다. \n" +
+                        "우리가 만드는 코드숨 공부방 좌석 예약 api에서 좌석을 예약하는 기능을 예로 들어보겠습니다. ")
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))


### PR DESCRIPTION
기존에는 회고와 계획의 글자수를 제한하지 않고 있었습니다.
그래서 사용자가 회고나 계획을 아무런 제약없이 작성할 수 있었습니다.
따라서 회고는 100자 이상 1000자 이하, 계획은 1000자 이하로 제한했습니다.