### PR TITLE
예약 수정상태일땐 수정취소를 누를시에 상세보기 상태로 돌아가라

### DIFF
--- a/app-web/src/components/reservation/ReservationDialog.tsx
+++ b/app-web/src/components/reservation/ReservationDialog.tsx
@@ -202,7 +202,8 @@ function ApplyReservationDialog({ onClose, onApply, onUpdate }: {
             variant="outlined"
             size="small"
           >
-            취소
+            {isUpdate && '수정 취소'}
+            {!isUpdate && '닫기'}
           </Button>
           <Button
             onClick={handleClick}

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -48,10 +48,16 @@ export default function Reservations() {
 
   const dispatch = useAppDispatch();
 
-  const { isOpenReservationsModal, date, content, id } = useAppSelector(get('reservations'));
+  const { isOpenReservationsModal, isUpdate, date, content, id } = useAppSelector(get('reservations'));
   const { isOpenRetrospectModal, retrospectives } = useAppSelector(get('retrospectives'));
 
   const onClickToggleReservationsModal = () => {
+    if (isUpdate) {
+      dispatch(saveIsDetail(true));
+      dispatch(saveIsUpdate(false));
+      return;
+    }
+
     dispatch(toggleReservationsModal());
     dispatch(resetReservations());
   };


### PR DESCRIPTION
기존엔 수정을 하던 경우여도 취소를 누르면 모달 자체가 닫혔었습니다. 
수정취소 버튼이라고 명시하고 클릭시 수정상태가 취소되도록 했습니다.