### PR TITLE
Date 객체를 만들어라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Date.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Date.java
@@ -1,0 +1,47 @@
+package com.codesoom.myseat.domain;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class Date {
+
+    private static final DateTimeFormatter DATE_FORMAT
+            = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Getter
+    private String date;
+
+    public Date(String date) {
+        this.date = date;
+    }
+
+    /**
+     * 주어진 날짜가 오늘보다 과거인지 확인합니다.
+     *
+     * @return 오늘보다 과거라면 true, 아니라면 false
+     */
+    public boolean isBeforeDate() {
+        return toLocalDate().isBefore(LocalDate.now());
+    }
+
+    /**
+     * 주어진 날짜의 요일이 주말인지 확인합니다.
+     *
+     * @return 토요일 혹은 일요일이라면 true, 아니라면 false
+     */
+    public boolean isWeekend() {
+        return toLocalDate().getDayOfWeek().getValue() > 5;
+    }
+
+    /**
+     * 문자열로 주어진 날짜를 LocalDate 형식으로 변환합니다.
+     *
+     * @return 변환된 LocalDate 형식
+     */
+    private LocalDate toLocalDate() {
+        return LocalDate.parse(this.date, DATE_FORMAT);
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/domain/DateTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/domain/DateTest.java
@@ -1,0 +1,40 @@
+package com.codesoom.myseat.domain;
+
+import com.codesoom.myseat.utils.DateUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateTest {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @DisplayName("오늘보다 과거이면 true를, 아니라면 false를 반환한다.")
+    @Test
+    void isBeforeDateTest() {
+        //given
+        Date before = new Date(LocalDate.now().minusDays(1L).format(DATE_FORMAT));
+        Date after = new Date(LocalDate.now().plusDays(1L).format(DATE_FORMAT));
+        //when & then
+        assertThat(before.isBeforeDate()).isTrue();
+        assertThat(after.isBeforeDate()).isFalse();
+    }
+
+    @DisplayName("주말이라면 true를, 평일이라면 false를 반환한다.")
+    @Test
+    void isWeekendTest() {
+        //given
+        Date saturday = new Date("2022-10-22");
+        Date sunday = new Date("2022-10-23");
+        Date friday = new Date("2022-10-21");
+        //when & then
+        assertThat(saturday.isWeekend()).isTrue();
+        assertThat(sunday.isWeekend()).isTrue();
+        assertThat(friday.isWeekend()).isFalse();
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/domain/DateTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/domain/DateTest.java
@@ -1,6 +1,5 @@
 package com.codesoom.myseat.domain;
 
-import com.codesoom.myseat.utils.DateUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
기존에는 date를 문자열로 관리하고 있었습니다.
하지만 date에 대한 책임이 늘어남에 따라 책임을 갖는 `Date`객체를 따로 생성하였습니다.

앞으로는 엔티티의 date를 이 `Date`객체로 관리할 수 있습니다.