### PR TITLE
회고 수정 API를 리팩토링을 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
@@ -43,6 +43,6 @@ public class RetrospectiveUpdateController {
         User user = userService.findById(principal.getId());
         String content = request.getContent();
 
-        retrospectiveUpdateService.updateRetrospective(id, user, content);
+        retrospectiveUpdateService.update(id, user, content);
     }
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -65,6 +65,15 @@ public class Reservation {
     }
 
     /**
+     * 회고내용을 수정합니다.
+     *
+     * @return 회고 내용 수정
+     */
+    public void updateRetrospective(String content) {
+        this.retrospective.updateContent(content);
+    }
+
+    /**
      * 회고가 null이 아니면 true, 그렇지 않으면 false를 반환합니다.
      * 
      * @return 회고가 null이면 true, 그렇지 않으면 false

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
@@ -1,12 +1,9 @@
 package com.codesoom.myseat.services.reservations.retrospectives;
 
 import com.codesoom.myseat.domain.Reservation;
-import com.codesoom.myseat.domain.Retrospective;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
-import com.codesoom.myseat.exceptions.RetrospectiveNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
-import com.codesoom.myseat.repositories.RetrospectiveRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class RetrospectiveUpdateService {
 
-    private final RetrospectiveRepository retrospectiveRepository;
     private final ReservationRepository reservationRepository;
 
-    public RetrospectiveUpdateService(RetrospectiveRepository retrospectiveRepository, ReservationRepository reservationRepository) {
-        this.retrospectiveRepository = retrospectiveRepository;
+    public RetrospectiveUpdateService(ReservationRepository reservationRepository) {
         this.reservationRepository = reservationRepository;
     }
 
@@ -29,22 +24,16 @@ public class RetrospectiveUpdateService {
      * @param reservationId 예약 Id
      * @param user 회원
      * @param content 수정 할 회고 내용
-     * @throws NotOwnedReservationException 요청한 회원이 해당 예약에 대해 회고를 작성하는 경우
-     * @throws RetrospectiveNotFoundException 회고 Id를 찾지 못한 경우
+     * @throws NotOwnedReservationException 회원이 해당 예약을 소유하지 않는 경우
      */
     @Transactional
-    public Retrospective updateRetrospective(final Long reservationId,
-                                             final User user,
-                                             final String content) {
+    public void update(final Long reservationId,
+                       final User user,
+                       final String content) {
         Reservation reservation = reservationRepository.findByIdAndUser_Id(reservationId, user.getId())
                 .orElseThrow(NotOwnedReservationException::new);
 
-        Retrospective retrospective = retrospectiveRepository.findByReservationId(reservation.getId())
-                .orElseThrow(RetrospectiveNotFoundException::new);
-
-        retrospective.updateContent(content);
-
-        return retrospective;
+        reservation.updateRetrospective(content);
     }
 
 }

--- a/app-server/http-request/local/회고수정.http
+++ b/app-server/http-request/local/회고수정.http
@@ -1,4 +1,4 @@
-PUT http://localhost:8080/reservations/1/retrospectives/1
+PUT http://localhost:8080/reservations/1/retrospectives
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer
 


### PR DESCRIPTION
기존 코드는 **retrospective가** **reservation에** **retrospective의** **content를** **수정** **한다.** 로 동작을 하지만 동작이 어색합니다.

실제로는 **reservation이** **retrospective의** **content를** **수정한다.** 로 동작을 해야 자연스럽습니다.

위에 행동에 맞게 리팩토링을 했습니다.
