### PR TITLE
mariadb 프로필이 아닌 경우 샘플데이터를 넣어라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 
 @Component
-@Profile("local-test")
+@Profile("!mariadb")
 public class DbInit {
     private final UserRepository userRepo;
     private final RoleRepository roleRepo;

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -1,5 +1,4 @@
 spring:
-  profiles: local-test
   datasource:
     url: ${url:jdbc:mariadb://localhost:3306/myseattest}
     username: root


### PR DESCRIPTION
기존에는 로컬에서 실행할 때 프로필을 local-test로 설정해줘야 했습니다.
그래서 [API Server README](https://github.com/CodeSoom-Project/my-seat/tree/main/app-server#readme)의 설명대로 실행하면 프로필이 없어서 오류가 발생했습니다.
따라서 배포용 프로필(mariadb)이 아닌 경우에 DBInit 클래스가 실행되도록 수정하여, 다른 분들이 로컬에서 실행할 때 별도의 프로필 설정을 할 필요가 없도록 했습니다.