### PR TITLE
방문 일자의 예약 내역이 이미 존재하지만 취소된 예약이면 예약할 수 있도록 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
@@ -2,6 +2,7 @@ package com.codesoom.myseat.repositories;
 
 import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.enums.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -38,6 +39,15 @@ public interface ReservationRepository
     boolean existsByDateAndUser_Id(Date date, Long id);
 
     /**
+     * 주어진 방문 일자와 회원 id로 예약 내역을 조회합니다.
+     * 
+     * @param date 방문 일자
+     * @param userId 회원 id
+     * @return 예약 내역
+     */
+    Optional<Reservation> findByDateAndUser_Id(Date date, Long userId);
+
+    /**
      * 주어진 회원 id로 예약 내역을 모두 조회합니다.
      *
      * @param id 회원 id
@@ -71,4 +81,14 @@ public interface ReservationRepository
      * @return 조회된 예약
      */
     Optional<Reservation> findById(Long id);
+
+    /**
+     * 주어진 방문 일자와 회원 id, 특정 상태가 아닌 예약이 존재하면 true, 그렇지 않으면 false를 반환합니다.
+     * 
+     * @param date 방문 일자
+     * @param userId 회원 id
+     * @param status 예약 상태
+     * @return 주어진 방문 일자와 회원 id로 취소된 예약이 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByDateAndUser_IdAndStatusNot(Date date, Long userId, ReservationStatus status);
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
@@ -4,6 +4,7 @@ import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.exceptions.ContentTooLongException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
@@ -77,11 +78,11 @@ public class ReservationAddService {
      * 중복된 예약이면 true, 그렇지 않으면 false를 반환합니다.
      * 
      * @param date 방문 일자
-     * @param id 회원 id
+     * @param userId 회원 id
      * @return 중복된 예약이면 true, 그렇지 않으면 false
      */
-    public boolean isDuplicateReservation(Date date, Long id) {
-        return reservationRepo.existsByDateAndUser_Id(date, id);
+    public boolean isDuplicateReservation(Date date, Long userId) {
+        return reservationRepo.existsByDateAndUser_IdAndStatusNot(date, userId, ReservationStatus.CANCELED);
     }
 
     /**
@@ -95,4 +96,5 @@ public class ReservationAddService {
         return reservationRepo.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException());
     }
+    
 }


### PR DESCRIPTION
기존에는 주어진 방문 일자에 대한 예약내역이 존재하면 무조건 해당 날짜에 예약이 불가능 했었습니다.
하지만 실수로 예약을 취소한 경우가 있을 수 있기 때문에,
만약 주어진 방문 일자에 대한 예약 내역이 존재하지만 취소된 예약이라면 예약이 가능하도록 수정 했습니다.
