### PR TITLE
모바일에서도 예약 목록을 잘 보이게 하라

### DIFF
--- a/app-web/src/components/reservations/ReservationsTable.tsx
+++ b/app-web/src/components/reservations/ReservationsTable.tsx
@@ -45,10 +45,27 @@ interface TablePaginationActionsProps {
   )=> void;
 }
 
+const StyledTable = styled(Table)({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
 const StyledTableCell = styled(TableCell)({
   [`&.${tableCellClasses.head}`]: {
     backgroundColor: '#1976d2',
     color: '#ffff',
+  },
+});
+
+const StyledPTag = styled('p')({
+  width: 800,
+  height: 20,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  '@media (max-width: 767px)': {
+    width: 150,
   },
 });
 
@@ -211,7 +228,7 @@ export default function ReservationsTable({
 
   return (
     <TableContainer component={Paper}>
-      <Table>
+      <StyledTable>
         <TableHead>
           <TableRow>
             <StyledTableCell align="center">계획 일자</StyledTableCell>
@@ -225,9 +242,9 @@ export default function ReservationsTable({
         <TableBody>
           {reservations.slice(startRow, endRow).map(({ id, date, content, status }: Reservations) => (
             <TableRow key={id}>
-              <TableCell align="center">{date}</TableCell>
-              <TableCell align="left">{content}</TableCell>
-              <TableCell align="center">
+              <StyledTableCell align="center">{date}</StyledTableCell>
+              <StyledTableCell align="left"><StyledPTag>{content}</StyledPTag></StyledTableCell>
+              <StyledTableCell align="center">
                 {status === 'CANCELED' ? (
                   <div>
                     {statusName[status]}
@@ -239,23 +256,33 @@ export default function ReservationsTable({
                     {statusName[status]}
                   </Button>
                 )}
-              </TableCell>
-              <TableCell align="center">
-                <Button onClick={handleClickReservationDetail(id, status)}>
-                  상세보기
-                </Button>
-              </TableCell>
-              <TableCell align="center">
+              </StyledTableCell>
+              <StyledTableCell align="center">
                 {status === 'CANCELED' ? (
                   <div>
-                    예약이 취소되었습니다.
+                    상세보기
+                  </div>
+                ) : (
+                  <Button
+                    onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                      handleClickReservationDetail(e, id);
+                      dispatch(saveIsDetail(true));
+                    }}>
+                    상세보기
+                  </Button>
+                )}
+              </StyledTableCell>
+              <StyledTableCell align="center">
+                {status === 'CANCELED' ? (
+                  <div>
+                    X
                   </div>
                 ) : (
                   <Button onClick={() => onClickCancelReservation(id)}>
                     예약취소
                   </Button>
                 )}
-              </TableCell>
+              </StyledTableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -273,7 +300,7 @@ export default function ReservationsTable({
             />
           </TableRow>
         </TableFooter>
-      </Table>
+      </StyledTable>
     </TableContainer>
   );
 }

--- a/app-web/src/pages/Reservations.tsx
+++ b/app-web/src/pages/Reservations.tsx
@@ -35,14 +35,9 @@ const Wrap = styled.div({
 
 const Header = styled.div({
   display: 'flex',
-  justifyContent: 'space-between',
+  justifyContent: 'flex-end',
   width: '100%',
   marginBottom: '1rem',
-});
-
-const Title = styled.h1({
-  fontSize: '2rem',
-  margin: '0',
 });
 
 export default function Reservations() {
@@ -165,10 +160,9 @@ export default function Reservations() {
 
       <Wrap>
         <Header>
-          <Title>예약내역</Title>
-
           <Button
-            style={{ fontSize: '2rem' }}
+            variant="outlined"
+            size="large"
             onClick={() => {
               onClickToggleReservationsModal();
               dispatch(saveIsDetail(false));


### PR DESCRIPTION
![Pasted image 20221025164409](https://user-images.githubusercontent.com/30693333/197721386-13ae2f9f-2072-408f-b7ea-da26d4f66388.png)
기존에는 모바일 환경에서 예약 목록을 제대로 보지 못하였습니다.

수정 후 
![image](https://user-images.githubusercontent.com/30693333/197721590-6dab618c-34d4-40cd-a305-97675decca89.png)

![image](https://user-images.githubusercontent.com/30693333/197721741-9572068b-a34d-46ec-a161-90913dd8dfe9.png)
모바일에서 가독성을 위해 '예약이 취소되었습니다 '-> ' X ' 로 변경하였습니다.

header에서 예약내역이라는 title을 삭제하였습니다.