### PR TITLE
예약 생성, 수정 시 날짜가 예약 가능한 날짜인지 검사하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -97,5 +97,11 @@ public class ControllerErrorAdvice {
     public String handleCannotUpdateCanceledReservation() {
         return "취소된 예약은 수정할 수 없습니다. 취소되지 않은 예약으로 다시 시도해주세요.";
     }
-    
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(NotReservableDateException.class)
+    public String handleNotReservableDateException(NotReservableDateException e) {
+        return e.getMessage();
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/NotReservableDateException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/NotReservableDateException.java
@@ -1,0 +1,16 @@
+package com.codesoom.myseat.exceptions;
+
+/** 요청한 날짜가 예약이 불가한 경우 던짐 */
+public class NotReservableDateException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "요청하신 예약일은 예약이 불가합니다.";
+
+    public NotReservableDateException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public NotReservableDateException(String message) {
+        super(message);
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
@@ -7,6 +7,7 @@ import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.exceptions.ContentTooLongException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.PlanRepository;
 import com.codesoom.myseat.repositories.ReservationRepository;
@@ -49,16 +50,19 @@ public class ReservationAddService {
             String date,
             String content
     ) {
-        if(isDuplicateReservation(new Date(date), user.getId())) {
+        Date givenDate = new Date(date);
+        if (!givenDate.isReservable()) {
+            throw new NotReservableDateException();
+        }
+        if(isDuplicateReservation(givenDate, user.getId())) {
             throw new AlreadyReservedException();
         }
-        
+
         Plan plan = Plan.builder()
                     .content(content)
                     .build();
-
         Reservation reservation = Reservation.builder()
-                .date(new Date(date))
+                .date(givenDate)
                 .user(user)
                 .plan(plan)
                 .build();

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -6,6 +6,7 @@ import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.exceptions.CannotUpdateCanceledReservationException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import org.springframework.stereotype.Service;
@@ -36,7 +37,10 @@ public class ReservationUpdateService {
     public void updateReservation(Long userId, Long id, ReservationRequest request) {
         Reservation reservation = repository.findById(id)
                 .orElseThrow(ReservationNotFoundException::new);
-        
+        Date date = new Date(request.getDate());
+        if (!date.isReservable()) {
+            throw new NotReservableDateException();
+        }
         if(reservation.isCanceled()) {
             throw new CannotUpdateCanceledReservationException();
         }
@@ -44,7 +48,7 @@ public class ReservationUpdateService {
             throw new NotOwnedReservationException();
         }
         if (reservation.isDifferentDate(reservation.getDate())) {
-            if (hasSameDateReservation(new Date(request.getDate()), userId)) {
+            if (hasSameDateReservation(date, userId)) {
                 throw new AlreadyReservedException();
             }
         }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationAddControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationAddControllerTest.java
@@ -1,8 +1,13 @@
 package com.codesoom.myseat.controllers.reservations;
 
+import com.codesoom.myseat.domain.Date;
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationRequest;
+import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationAddService;
 import com.codesoom.myseat.services.users.UserService;
@@ -18,6 +23,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -41,9 +49,27 @@ class ReservationAddControllerTest {
     @MockBean
     private ReservationAddService reservationAddService;
 
+    Date getReservableDate() {
+        long plusDays = 0;
+        LocalDate now = LocalDate.now();
+        if (now.getDayOfWeek().getValue() < 6) {
+            plusDays = 6 - now.getDayOfWeek().getValue();
+        }
+        LocalDate saturday = now.plusDays(plusDays);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return new Date(saturday.format(dateFormat));
+    }
+
+    Date getNotReservableDate() {
+        LocalDate notReservableDate =  LocalDate.now().minusDays(1);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return new Date(notReservableDate.format(dateFormat));
+    }
+
     @Test
     @DisplayName("POST /reservations 요청 시 상태코드 204를 응답한다")
     void POST_reservations_responses_status_code_204() throws Exception {
+        Date date = getReservableDate();
         User mockUser = User.builder()
                 .id(1L)
                 .name("김철수")
@@ -58,9 +84,17 @@ class ReservationAddControllerTest {
                 .willReturn(mockUser);
 
         ReservationRequest request = ReservationRequest.builder()
-                .date("2022-10-11")
+                .date(date.getDate())
                 .content("책읽기, 코테풀기")
                 .build();
+
+        given(reservationAddService.createReservation(mockUser, date.getDate(), "책읽기, 코테풀기"))
+                .willReturn(Reservation.builder()
+                        .user(mockUser)
+                        .plan(Plan.builder().content("책읽기, 코테풀기").build())
+                        .date(date)
+                        .status(ReservationStatus.RESERVED)
+                        .build());
 
         ResultActions result =  mockMvc.perform(post("/reservations")
                 .header("Authorization", "Bearer " + ACCESS_TOKEN)
@@ -73,6 +107,7 @@ class ReservationAddControllerTest {
     @Test
     @DisplayName("이미 예약 내역이 존재하는 방문 일자가 주어지면 상태코드 400을 응답한다")
     void If_already_existing_date_given_it_responses_status_code_400() throws Exception {
+        Date date = getReservableDate();
         User mockUser = User.builder()
                 .id(1L)
                 .name("김철수")
@@ -86,11 +121,44 @@ class ReservationAddControllerTest {
         given(userService.findById(1L))
                 .willReturn(mockUser);
 
-        given(reservationAddService.createReservation(mockUser, "2022-10-11", "책읽기, 코테풀기"))
+        given(reservationAddService.createReservation(mockUser, date.getDate(), "책읽기, 코테풀기"))
                 .willThrow(AlreadyReservedException.class);
 
         ReservationRequest request = ReservationRequest.builder()
-                .date("2022-10-11")
+                .date(date.getDate())
+                .content("책읽기, 코테풀기")
+                .build();
+
+        ResultActions result = mockMvc.perform(post("/reservations")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("예약이 불가능한 날짜가 주어지면 상태코드 400을 응답한다")
+    void If_not_reservable_date_given_it_responses_status_code_400() throws Exception {
+        Date notReservableDate = getNotReservableDate();
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+
+        given(authService.parseToken(ACCESS_TOKEN))
+                .willReturn(1L);
+
+        given(userService.findById(1L))
+                .willReturn(mockUser);
+
+        given(reservationAddService.createReservation(mockUser,notReservableDate.getDate(), "책읽기, 코테풀기"))
+                .willThrow(NotReservableDateException.class);
+
+        ReservationRequest request = ReservationRequest.builder()
+                .date(notReservableDate.getDate())
                 .content("책읽기, 코테풀기")
                 .build();
 

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateControllerTest.java
@@ -3,10 +3,12 @@ package com.codesoom.myseat.controllers.reservations;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationUpdateService;
 import com.codesoom.myseat.services.users.UserService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -120,4 +122,20 @@ class ReservationUpdateControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound());
     }
+
+    @DisplayName("예약 불가능한 날짜가 주어지면 400 bad request를 응답한다.")
+    @Test
+    void PUT_reservation_update_with_400_status() throws Exception {
+        ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+        doThrow(NotReservableDateException.class)
+                .when(reservationUpdateService)
+                .updateReservation(anyLong(), anyLong(), any(ReservationRequest.class));
+
+        mockMvc.perform(put("/reservations/999")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationAddServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationAddServiceTest.java
@@ -5,6 +5,7 @@ import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.repositories.PlanRepository;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Optional;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,7 +39,7 @@ class ReservationAddServiceTest {
     }
     
     @Test
-    @DisplayName("createReservation 메서드는 SeatReservation을 반환한다")
+    @DisplayName("createReservation 메서드는 Reservation을 반환한다")
     void createReservation_returns_SeatReservation() {
         User mockUser = User.builder()
                 .id(1L)
@@ -93,26 +96,44 @@ class ReservationAddServiceTest {
                 .email("soo@email.com")
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
                 .build();
-        
+
         Reservation mockReservation = Reservation.builder()
                 .id(2L)
                 .date(new Date("2022-10-11"))
                 .status(ReservationStatus.CANCELED)
                 .user(mockUser)
                 .build();
-        
+
         given(reservationRepo.existsByDateAndUser_IdAndStatusNot(new Date("2022-10-11"), 1L, ReservationStatus.CANCELED))
                 .willReturn(false);
-        
+
         given(reservationRepo.findByDateAndUser_Id(new Date("2022-10-11"), 1L))
                 .willReturn(Optional.of(mockReservation));
-        
+
         Reservation reservation
                 = service.createReservation(mockUser, "2022-10-11", "책읽기, 코테 풀기");
-        
+
         assertThat(reservation.getUser().getEmail()).isEqualTo("soo@email.com");
         assertThat(reservation.getDate().getDate()).isEqualTo("2022-10-11");
         assertThat(reservation.getPlan().getContent()).isEqualTo("책읽기, 코테 풀기");
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RETROSPECTIVE_WAITING);
     }
+
+    @Test
+    @DisplayName("예약이 불가능한 날짜가 주어지면 NotReservableException을 던진다")
+    void throw_not_reservable_exception_with_invalid_date() {
+        //given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+        String invalidDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        //when & then
+        assertThatThrownBy(() -> service.createReservation(mockUser, invalidDate, "공부하기"))
+                .isInstanceOf(NotReservableDateException.class);
+    }
+
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationAddServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationAddServiceTest.java
@@ -37,10 +37,22 @@ class ReservationAddServiceTest {
         
         service = new ReservationAddService(planRepo, reservationRepo);
     }
-    
+
+    Date getReservableDate() {
+        long plusDays = 0;
+        LocalDate now = LocalDate.now();
+        if (now.getDayOfWeek().getValue() < 6) {
+            plusDays = 6 - now.getDayOfWeek().getValue();
+        }
+        LocalDate saturday = now.plusDays(plusDays);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return new Date(saturday.format(dateFormat));
+    }
+
     @Test
     @DisplayName("createReservation 메서드는 Reservation을 반환한다")
     void createReservation_returns_SeatReservation() {
+        Date date = getReservableDate();
         User mockUser = User.builder()
                 .id(1L)
                 .name("김철수")
@@ -51,11 +63,11 @@ class ReservationAddServiceTest {
         given(reservationRepo.existsByDateAndUser_IdAndStatusNot(new Date("2022-10-11"), 1L, ReservationStatus.CANCELED))
                 .willReturn(false);
 
-        Reservation reservation 
-                = service.createReservation(mockUser, "2022-10-11", "책읽기, 코테 풀기");
+        Reservation reservation
+                = service.createReservation(mockUser, date.getDate(), "책읽기, 코테 풀기");
         
         assertThat(reservation.getUser().getEmail()).isEqualTo("soo@email.com");
-        assertThat(reservation.getDate().getDate()).isEqualTo("2022-10-11");
+        assertThat(reservation.getDate()).isEqualTo(date);
         assertThat(reservation.getPlan().getContent()).isEqualTo("책읽기, 코테 풀기");
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RETROSPECTIVE_WAITING);
     }
@@ -63,6 +75,7 @@ class ReservationAddServiceTest {
     @Test
     @DisplayName("이미 예약 했던 방문 일자가 주어지면 AlreadyReservedException를 던진다")
     void If_date_that_already_reserved_given_It_throws_AlreadyReservedException() {
+        Date date = getReservableDate();
         User mockUser = User.builder()
                 .id(1L)
                 .name("김철수")
@@ -72,24 +85,25 @@ class ReservationAddServiceTest {
         
         Reservation mockReservation = Reservation.builder()
                 .id(2L)
-                .date(new Date("2022-10-11"))
+                .date(date)
                 .status(ReservationStatus.RETROSPECTIVE_WAITING)
                 .user(mockUser)
                 .build();
 
-        given(reservationRepo.existsByDateAndUser_IdAndStatusNot(new Date("2022-10-11"), 1L, ReservationStatus.CANCELED))
+        given(reservationRepo.existsByDateAndUser_IdAndStatusNot(date, 1L, ReservationStatus.CANCELED))
                 .willReturn(true);
         
-        given(reservationRepo.findByDateAndUser_Id(new Date("2022-10-11"), 1L))
+        given(reservationRepo.findByDateAndUser_Id(date, 1L))
                 .willReturn(Optional.of(mockReservation));
          
-        assertThatThrownBy(() -> service.createReservation(mockUser, "2022-10-11", "책읽기, 코테 풀기"))
+        assertThatThrownBy(() -> service.createReservation(mockUser, date.getDate(), "책읽기, 코테 풀기"))
                 .isInstanceOf(AlreadyReservedException.class);
     }
     
     @Test
     @DisplayName("해당 방문 일자의 예약이 존재하지만 취소된 예약이면 생성된 Reservation을 반환한다.")
     void If_date_that_already_reserved_but_canceled_given_It_returns_reservation() {
+        Date date = getReservableDate();
         User mockUser = User.builder()
                 .id(1L)
                 .name("김철수")
@@ -99,7 +113,7 @@ class ReservationAddServiceTest {
 
         Reservation mockReservation = Reservation.builder()
                 .id(2L)
-                .date(new Date("2022-10-11"))
+                .date(date)
                 .status(ReservationStatus.CANCELED)
                 .user(mockUser)
                 .build();
@@ -111,10 +125,10 @@ class ReservationAddServiceTest {
                 .willReturn(Optional.of(mockReservation));
 
         Reservation reservation
-                = service.createReservation(mockUser, "2022-10-11", "책읽기, 코테 풀기");
+                = service.createReservation(mockUser, date.getDate(), "책읽기, 코테 풀기");
 
         assertThat(reservation.getUser().getEmail()).isEqualTo("soo@email.com");
-        assertThat(reservation.getDate().getDate()).isEqualTo("2022-10-11");
+        assertThat(reservation.getDate()).isEqualTo(date);
         assertThat(reservation.getPlan().getContent()).isEqualTo("책읽기, 코테 풀기");
         assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RETROSPECTIVE_WAITING);
     }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
@@ -8,6 +8,7 @@ import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.CannotUpdateCanceledReservationException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
+import com.codesoom.myseat.exceptions.NotReservableDateException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -136,6 +137,34 @@ class ReservationUpdateServiceTest {
 
                     //when
                     assertThrows(CannotUpdateCanceledReservationException.class,
+                            () -> service.updateReservation(USER_ID, 1L, request));
+                }
+            }
+
+            @DisplayName("주어진 날짜가 예약 가능한 날짜가 아니면")
+            @Nested
+            class Context_with_invalid_date {
+                @BeforeEach
+                void setUp() {
+                    RESERVATION = Reservation.builder()
+                            .user(USER)
+                            .date(new Date("2022-10-17"))
+                            .plan(PLAN)
+                            .status(ReservationStatus.CANCELED)
+                            .build();
+                    given(repository.findById(same(1L)))
+                            .willReturn(Optional.of(RESERVATION));
+                }
+
+                @DisplayName("NotReservableDateException을 던진다.")
+                @Test
+                void will_throw_not_reservable_exception() {
+                    //given
+                    ReservationRequest request
+                            = new ReservationRequest("2022-10-18", "수정 데이터");
+
+                    //when
+                    assertThrows(NotReservableDateException.class,
                             () -> service.updateReservation(USER_ID, 1L, request));
                 }
             }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationUpdateServiceTest.java
@@ -20,6 +20,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +41,17 @@ class ReservationUpdateServiceTest {
 
     private final Long USER_ID = 1L;
 
+    Date getReservableDate() {
+        long plusDays = 0;
+        LocalDate now = LocalDate.now();
+        if (now.getDayOfWeek().getValue() < 6) {
+            plusDays = 6 - now.getDayOfWeek().getValue();
+        }
+        LocalDate saturday = now.plusDays(plusDays);
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return new Date(saturday.format(dateFormat));
+    }
+
     @DisplayName("updateReservation 메소드는")
     @Nested
     class Describe_update_reservation {
@@ -56,6 +69,7 @@ class ReservationUpdateServiceTest {
                     .build();
             private final Plan PLAN = Plan.builder().content("공부").build();
             private Reservation RESERVATION;
+            private Date DATE = getReservableDate();
             
             @DisplayName("요청한 회원 소유의 예약이면")
             @Nested
@@ -64,7 +78,7 @@ class ReservationUpdateServiceTest {
                 void setUp() {
                     RESERVATION = Reservation.builder()
                             .user(USER)
-                            .date(new Date("2022-10-17"))
+                            .date(DATE)
                             .plan(PLAN)
                             .build();
                     given(repository.findById(same(EXIST_ID)))
@@ -75,7 +89,7 @@ class ReservationUpdateServiceTest {
                 @Test
                 void will_update_successfully() {
                     //given
-                    ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+                    ReservationRequest request = new ReservationRequest(DATE.getDate(), "수정 데이터");
 
                     //when
                     service.updateReservation(USER_ID, EXIST_ID, request);
@@ -93,7 +107,7 @@ class ReservationUpdateServiceTest {
                 void setUp() {
                     RESERVATION = Reservation.builder()
                             .user(USER)
-                            .date(new Date("2022-10-17"))
+                            .date(DATE)
                             .plan(PLAN)
                             .build();
                     given(repository.findById(same(EXIST_ID)))
@@ -105,7 +119,7 @@ class ReservationUpdateServiceTest {
                 void will_throw_exception() {
                     //given
                     Long NOT_OWNED_USER_ID = 888L;
-                    ReservationRequest request = new ReservationRequest("2022-10-18", "수정 데이터");
+                    ReservationRequest request = new ReservationRequest(DATE.getDate(), "수정 데이터");
 
                     //when
                     assertThrows(NotOwnedReservationException.class,
@@ -120,7 +134,7 @@ class ReservationUpdateServiceTest {
                 void setUp() {
                     RESERVATION = Reservation.builder()
                             .user(USER)
-                            .date(new Date("2022-10-17"))
+                            .date(DATE)
                             .plan(PLAN)
                             .status(ReservationStatus.CANCELED)
                             .build();
@@ -133,7 +147,7 @@ class ReservationUpdateServiceTest {
                 void will_throw_cannot_update_canceled_reservation_exception() {
                     //given
                     ReservationRequest request
-                            = new ReservationRequest("2022-10-18", "수정 데이터");
+                            = new ReservationRequest(DATE.getDate(), "수정 데이터");
 
                     //when
                     assertThrows(CannotUpdateCanceledReservationException.class,


### PR DESCRIPTION
현재는 모든 날짜에 예약이 가능합니다. 
하지만 현재 예약 정책상 `미래의 날짜 이면서 주말이어야 한다`를 지켜야 합니다.

따라서 예약 가능한 날짜인지 여부를 확인하는 로직을 추가하였습니다.