### PR TITLE
불필요한 주석을 제거하고, 코드 스타일을 통일시켜라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/config/ApplicationConfig.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/config/ApplicationConfig.java
@@ -7,8 +7,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class ApplicationConfig {
+    
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
@@ -18,7 +18,9 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig 
+        extends WebSecurityConfigurerAdapter {
+    
     private final AuthenticationService authService;
 
     public SecurityConfig(
@@ -39,7 +41,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .headers()
                 .addHeaderWriter(
                         new XFrameOptionsHeaderWriter(
-                                new WhiteListedAllowFromStrategy(Arrays.asList("localhost"))    // 여기!
+                                new WhiteListedAllowFromStrategy(Arrays.asList("localhost"))
                         )
                 )
                 .frameOptions().sameOrigin()

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -7,9 +7,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-/**
- * 컨트롤러에서 발생하는 예외를 처리한다.
- */
+/** 컨트롤러에서 발생하는 예외를 처리합니다. */
 @ResponseBody
 @ControllerAdvice
 public class ControllerErrorAdvice {

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/HealthCheckController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/HealthCheckController.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/")
 @CrossOrigin
 public class HealthCheckController {
+    
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public String healthCheck() {
         return "Hello";
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/login/LoginController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/login/LoginController.java
@@ -9,15 +9,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 로그인 컨트롤러
- */
+/** 로그인 컨트롤러 */
 @RestController
 @RequestMapping("/login")
 @CrossOrigin
 @Slf4j
 public class LoginController {
+    
     private final AuthenticationService authService;
+    
     private final UserService userService;
 
     public LoginController(
@@ -54,4 +54,5 @@ public class LoginController {
                 .name(name)
                 .build();
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/mypage/MyPageController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/mypage/MyPageController.java
@@ -15,14 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 마이페이지 컨트롤러
- */
+/** 마이페이지 컨트롤러 */
 @RestController
 @RequestMapping("/mypage")
 @CrossOrigin
 @Slf4j
 public class MyPageController {
+    
     private final UserService userService;
 
     public MyPageController(

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationAddController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationAddController.java
@@ -13,15 +13,15 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 좌석 예약 요청 컨트롤러
- */
+/** 예약 추가 컨트롤러 */
 @RestController
 @RequestMapping("/reservations")
 @CrossOrigin
 @Slf4j
 public class ReservationAddController {
+    
     private final ReservationAddService reservationAddService;
+    
     private final UserService userService;
 
     public ReservationAddController(
@@ -53,4 +53,5 @@ public class ReservationAddController {
 
         reservationAddService.createReservation(user, date, content);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationCancelController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationCancelController.java
@@ -8,9 +8,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 좌석 예약 취소 컨트롤러
- */
+/** 예약 취소 컨트롤러 */
 @Slf4j
 @CrossOrigin
 @RequestMapping("/reservations")
@@ -19,7 +17,9 @@ public class ReservationCancelController {
 
     private final ReservationCancelService cancelService;
 
-    public ReservationCancelController(ReservationCancelService cancelService) {
+    public ReservationCancelController(
+            ReservationCancelService cancelService
+    ) {
         this.cancelService = cancelService;
     }
 
@@ -32,8 +32,10 @@ public class ReservationCancelController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/{id}")
-    public void cancelReservation(@AuthenticationPrincipal UserAuthentication principal,
-                                  @PathVariable Long id) {
+    public void cancelReservation(
+            @AuthenticationPrincipal UserAuthentication principal, 
+            @PathVariable Long id
+    ) {
         log.debug("--------- 예약 취소 요쳥");
         log.debug("예약 id: {}", id);
         cancelService.cancelReservation(principal.getId(), id);

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
@@ -16,15 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 예약 상세 조회 컨트롤러
- */
+/** 예약 상세 조회 컨트롤러 */
 @CrossOrigin
 @RequestMapping("/reservations")
 @RestController
 public class ReservationDetailController {
     
     private final UserService userService;
+    
     private final ReservationDetailService service;
 
     public ReservationDetailController(

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationListController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationListController.java
@@ -17,18 +17,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.stream.Collectors;
 
-/**
- * 예약 목록 조회 컨트롤러
- */
+/** 예약 목록 조회 컨트롤러 */
 @CrossOrigin
 @RequestMapping("/reservations")
 @RestController
 public class ReservationListController {
 
     private final UserService userService;
+    
     private final ReservationListService service;
 
-    public ReservationListController(UserService userService, ReservationListService service) {
+    public ReservationListController(
+            UserService userService, 
+            ReservationListService service
+    ) {
         this.userService = userService;
         this.service = service;
     }
@@ -42,7 +44,9 @@ public class ReservationListController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public ReservationListResponse reservations(@AuthenticationPrincipal UserAuthentication principal) {
+    public ReservationListResponse reservations(
+            @AuthenticationPrincipal UserAuthentication principal
+    ) {
         User user = userService.findById(principal.getId());
 
         return new ReservationListResponse(

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationUpdateController.java
@@ -23,7 +23,9 @@ public class ReservationUpdateController {
 
     private final ReservationUpdateService service;
 
-    public ReservationUpdateController(ReservationUpdateService service) {
+    public ReservationUpdateController(
+            ReservationUpdateService service
+    ) {
         this.service = service;
     }
 
@@ -38,9 +40,11 @@ public class ReservationUpdateController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/{id}")
-    public void updateReservation(@AuthenticationPrincipal UserAuthentication principal,
-                                  @PathVariable Long id,
-                                  @RequestBody ReservationRequest request) {
+    public void updateReservation(
+            @AuthenticationPrincipal UserAuthentication principal, 
+            @PathVariable Long id, 
+            @RequestBody ReservationRequest request
+    ) {
         service.updateReservation(principal.getId(), id, request);
     }
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
@@ -31,10 +31,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class RetrospectiveAddController {
 
     private final RetrospectiveAddService retrospectiveAddService;
+    
     private final UserService userService;
+    
     private final ReservationAddService reservationAddService;
 
-    public RetrospectiveAddController(RetrospectiveAddService retrospectiveAddService, UserService userService, ReservationAddService reservationAddService) {
+    public RetrospectiveAddController(
+            RetrospectiveAddService retrospectiveAddService, 
+            UserService userService, 
+            ReservationAddService reservationAddService
+    ) {
         this.retrospectiveAddService = retrospectiveAddService;
         this.userService = userService;
         this.reservationAddService = reservationAddService;
@@ -55,9 +61,9 @@ public class RetrospectiveAddController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void writeRetrospective(
             @AuthenticationPrincipal UserAuthentication principal,
-            @PathVariable final Long id,
-            @RequestBody final RetrospectiveRequest request)
-    {
+            @PathVariable Long id,
+            @RequestBody RetrospectiveRequest request
+    ) {
         User user = userService.findById(principal.getId());
         
         Reservation reservation = reservationAddService.findReservation(id);

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin
 @Slf4j
 public class RetrospectiveDetailController {
+    
     private final ReservationDetailService reservationDetailService;
+    
     private final RetrospectiveDetailService retrospectiveDetailService;
 
     public RetrospectiveDetailController(
@@ -56,4 +58,5 @@ public class RetrospectiveDetailController {
                 .content(retrospective.getContent())
                 .build();
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveUpdateController.java
@@ -24,9 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class RetrospectiveUpdateController {
 
     private final RetrospectiveUpdateService retrospectiveUpdateService;
+    
     private final UserService userService;
 
-    public RetrospectiveUpdateController(RetrospectiveUpdateService retrospectiveUpdateService, UserService userService) {
+    public RetrospectiveUpdateController(
+            RetrospectiveUpdateService retrospectiveUpdateService, 
+            UserService userService
+    ) {
         this.retrospectiveUpdateService = retrospectiveUpdateService;
         this.userService = userService;
     }
@@ -35,14 +39,14 @@ public class RetrospectiveUpdateController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateRetrospective(
-            @AuthenticationPrincipal final UserAuthentication principal,
-            @PathVariable("id") final Long id,
-            @RequestBody final RetrospectiveRequest request
+            @AuthenticationPrincipal UserAuthentication principal,
+            @PathVariable("id") Long id,
+            @RequestBody RetrospectiveRequest request
     ) {
-
         User user = userService.findById(principal.getId());
         String content = request.getContent();
 
         retrospectiveUpdateService.update(id, user, content);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/signup/SignupController.java
@@ -8,15 +8,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 회원 가입 컨트롤러
- */
+/** 회원 가입 컨트롤러 */
 @RestController
 @RequestMapping("/signup")
 @CrossOrigin
 @Slf4j
 public class SignupController {
+    
     private final SignupService service;
+    
     private final UserService userService;
 
     public SignupController(
@@ -38,8 +38,6 @@ public class SignupController {
     public void signUp(
             @RequestBody SignupRequest request
     ) {
-        log.info("request: " + request.toString());
-
         String email = request.getEmail();
         if(userService.isDuplicatedEmail(email)) {
             throw new DuplicatedEmailException();
@@ -50,4 +48,5 @@ public class SignupController {
 
         service.createUser(name, email, password);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/converters/ReservationStatusConverter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/converters/ReservationStatusConverter.java
@@ -7,15 +7,20 @@ import javax.persistence.Converter;
 
 /** DB에 저장된 값과, 정의한 ReservationStatus Enum을 매핑합니다. */
 @Converter
-public class ReservationStatusConverter implements AttributeConverter<ReservationStatus, Integer> {
+public class ReservationStatusConverter 
+        implements AttributeConverter<ReservationStatus, Integer> {
 
     @Override
-    public Integer convertToDatabaseColumn(ReservationStatus attribute) {
+    public Integer convertToDatabaseColumn(
+            ReservationStatus attribute
+    ) {
         return attribute.getNum();
     }
 
     @Override
-    public ReservationStatus convertToEntityAttribute(Integer dbData) {
+    public ReservationStatus convertToEntityAttribute(
+            Integer dbData
+    ) {
         return ReservationStatus.ofNum(dbData);
     }
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/db/DbInit.java
@@ -10,13 +10,19 @@ import javax.annotation.PostConstruct;
 @Component
 @Profile("!mariadb")
 public class DbInit {
+    
     private final UserRepository userRepo;
+    
     private final RoleRepository roleRepo;
+    
     private final ReservationRepository reservationRepo;
+    
     private final PlanRepository planRepo;
+    
     private final RetrospectiveRepository retrospectiveRepo;
 
     User user1;
+    
     User user2;
     
     public DbInit(
@@ -93,4 +99,5 @@ public class DbInit {
         planRepo.save(plan2);
         reservationRepo.save(reservation2);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Plan.java
@@ -10,9 +10,7 @@ import javax.persistence.*;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
-/**
- * 계획 엔티티
- */
+/** 계획 엔티티 */
 @Entity
 @Getter
 @Builder
@@ -20,6 +18,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @Slf4j
 public class Plan {
+    
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name="plan_id")
@@ -31,4 +30,5 @@ public class Plan {
     public void update(String content) {
         this.content = content;
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -14,9 +14,7 @@ import javax.persistence.*;
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.GenerationType.IDENTITY;
 
-/**
- * 좌석 예약 엔티티
- */
+/** 예약 엔티티 */
 @Entity
 @Getter
 @Builder

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Retrospective.java
@@ -15,7 +15,6 @@ import javax.persistence.OneToOne;
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.GenerationType.IDENTITY;
 
-
 @Entity
 @Getter
 @NoArgsConstructor
@@ -38,4 +37,5 @@ public class Retrospective {
     public void updateContent(String content) {
         this.content = content;
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Role.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Role.java
@@ -16,6 +16,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @Builder
 public class Role {
+    
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
@@ -24,4 +25,5 @@ public class Role {
 
     @Getter
     private String roleName;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -11,9 +11,7 @@ import javax.persistence.*;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
-/**
- * 회원 엔티티
- */
+/** 회원 엔티티 */
 @Entity
 @Getter
 @Builder
@@ -21,6 +19,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @Slf4j
 public class User {
+    
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name="user_id")
@@ -43,8 +42,7 @@ public class User {
             String password, 
             PasswordEncoder passwordEncoder
     ) {
-        log.info("password: " + password);
-        log.info("this.password: " + this.password);
         return passwordEncoder.matches(password, this.password);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/LoginRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/LoginRequest.java
@@ -5,15 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 로그인 요청 정보
- */
+/** 로그인 요청 정보 */
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginRequest {
+    
     private String email;
 
     private String password;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/LoginResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/LoginResponse.java
@@ -4,14 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 로그인 응답 정보
- */
+/** 로그인 응답 정보 */
 @Getter
 @Builder
 @AllArgsConstructor
 public class LoginResponse {
+    
     private String accessToken;
 
     private String name;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/MyPageResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/MyPageResponse.java
@@ -4,14 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 마이페이지 응답 정보
- */
+/** 마이페이지 응답 정보 */
 @Getter
 @Builder
 @AllArgsConstructor
 public class MyPageResponse {
+    
     String name;
     
     String email;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListResponse.java
@@ -12,7 +12,9 @@ public class ReservationListResponse {
 
     private List<ReservationResponse> reservations;
 
-    public ReservationListResponse(List<ReservationResponse> reservations) {
+    public ReservationListResponse(
+            List<ReservationResponse> reservations
+    ) {
         this.reservations = reservations;
     }
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationRequest.java
@@ -5,14 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 예약 요청 정보
- */
+/** 예약 추가 요청 정보 */
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ReservationRequest {
+    
     private String date;
+    
     private String content;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationResponse.java
@@ -10,11 +10,16 @@ import lombok.NoArgsConstructor;
 public class ReservationResponse {
 
     private Long id;
+    
     private String date;
+    
     private String content;
+    
     private String status;
 
-    public ReservationResponse(Reservation reservation) {
+    public ReservationResponse(
+            Reservation reservation
+    ) {
         this.id = reservation.getId();
         this.date = reservation.getDate().getDate();
         this.content = reservation.getPlan().getContent();

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveRequest.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class RetrospectiveRequest {
 
     String content;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/RetrospectiveResponse.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RetrospectiveResponse {
+    
     private Long id;
     
     private String content;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/SignupRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/SignupRequest.java
@@ -5,17 +5,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 회원 가입 요청 정보
- */
+/** 회원 가입 요청 정보 */
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignupRequest {
+    
     private String name;
-
+    
     private String email;
-
+    
     private String password;
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/enums/ReservationStatus.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/enums/ReservationStatus.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 import java.util.Arrays;
 
-/** 예약 상태 정의 */
+/** 예약 상태 */
 public enum ReservationStatus {
 
     RESERVED(0),    // 예약 완료
@@ -19,7 +19,9 @@ public enum ReservationStatus {
         this.num = num;
     }
 
-    public static ReservationStatus ofNum(Integer storedData) {
+    public static ReservationStatus ofNum(
+            Integer storedData
+    ) {
         return Arrays.stream(ReservationStatus.values())
                 .filter(it -> it.num == storedData)
                 .findAny()

--- a/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationErrorFilter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationErrorFilter.java
@@ -11,14 +11,17 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-/** 토큰 검증 필터에서 발생한 예외 처리 담당 */
+/** 토큰 검증 필터에서 발생한 예외를 처리합니다 */
 @Slf4j
-public class AuthenticationErrorFilter extends HttpFilter {
+public class AuthenticationErrorFilter 
+        extends HttpFilter {
 
     @Override
-    protected void doFilter(HttpServletRequest request,
-                            HttpServletResponse response,
-                            FilterChain chain) throws IOException, ServletException {
+    protected void doFilter(
+            HttpServletRequest request, 
+            HttpServletResponse response, 
+            FilterChain chain
+    ) throws IOException, ServletException {
         try {
             chain.doFilter(request, response);
         } catch (InvalidTokenException e) {

--- a/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/filters/AuthenticationFilter.java
@@ -21,7 +21,8 @@ import java.io.IOException;
 import java.util.List;
 
 @Slf4j
-public class AuthenticationFilter extends BasicAuthenticationFilter {
+public class AuthenticationFilter 
+        extends BasicAuthenticationFilter {
 
     private static final String TOKEN_PREFIX = "Bearer ";
 
@@ -72,7 +73,9 @@ public class AuthenticationFilter extends BasicAuthenticationFilter {
      * @return accessToken
      * @throws InvalidTokenException 유효하지 않은 토큰일 경우 던짐
      */
-    private String getAccessToken(HttpServletRequest request) {
+    private String getAccessToken(
+            HttpServletRequest request
+    ) {
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         log.info("header: " + token);
         if (Strings.isBlank(token)) {

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/PlanRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/PlanRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlanRepository 
         extends JpaRepository<Plan, Long> {
+    
     Plan save(Plan plan);
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/ReservationRepository.java
@@ -8,16 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * 좌석 예약 레포지토리
- */
+/** 예약 레포지토리 */
 public interface ReservationRepository
         extends JpaRepository<Reservation, Long> {
-    /**
-     * 
-     * @param s must not be {@literal null}.
-     * @return
-     */
+    
     Reservation save(Reservation s);
 
     /**
@@ -64,7 +58,6 @@ public interface ReservationRepository
      */
     Optional<Reservation> findByIdAndUser_Id(Long id, Long userId);
 
-
     /**
      * 예약한 회원이면 true, 그렇지 않으면 false를 반환합니다.
      *
@@ -91,4 +84,5 @@ public interface ReservationRepository
      * @return 주어진 방문 일자와 회원 id로 취소된 예약이 존재하면 true, 그렇지 않으면 false
      */
     boolean existsByDateAndUser_IdAndStatusNot(Date date, Long userId, ReservationStatus status);
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/RetrospectiveRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/RetrospectiveRepository.java
@@ -7,10 +7,12 @@ import java.util.Optional;
 
 public interface RetrospectiveRepository 
         extends JpaRepository<Retrospective, Long> {
+    
     /**
      * 주어진 예약 id로 조회된 회고를 반환합니다.
      * @param id 예약 id
      * @return 조회된 회고
      */
     Optional<Retrospective> findByReservationId(Long id);
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/RoleRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/RoleRepository.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 public interface RoleRepository 
         extends JpaRepository<Role, Long> {
+    
     List<Role> findAllByUserId(Long id);
 
     Role save(Role role);
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/repositories/UserRepository.java
@@ -5,9 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-/**
- * 회원 레포지토리
- */
+/** 회원 레포지토리 */
 public interface UserRepository
         extends JpaRepository<User, Long> {
 
@@ -42,4 +40,5 @@ public interface UserRepository
      * @return 회원 조회에 성공하면 true, 그렇지 않으면 false
      */
     Boolean existsByEmail(String email);
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/security/UserAuthentication.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/security/UserAuthentication.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 public class UserAuthentication 
         extends AbstractAuthenticationToken {
+    
     private final Long id;
 
     public UserAuthentication(
@@ -51,4 +52,5 @@ public class UserAuthentication
                 .map(role -> new SimpleGrantedAuthority(role.getRoleName()))
                 .collect(Collectors.toList());
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/auth/AuthenticationService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/auth/AuthenticationService.java
@@ -13,18 +13,18 @@ import java.util.List;
 
 @Service
 public class AuthenticationService {
-    private final UserRepository userRepo;
+    
     private final RoleRepository roleRepo;
+    
     private final JwtUtil jwtUtil;
+    
     private final PasswordEncoder passwordEncoder;
 
     public AuthenticationService(
-            UserRepository userRepo, 
             RoleRepository roleRepo, 
             JwtUtil jwtUtil, 
             PasswordEncoder passwordEncoder
     ) {
-        this.userRepo = userRepo;
         this.roleRepo = roleRepo;
         this.jwtUtil = jwtUtil;
         this.passwordEncoder = passwordEncoder;
@@ -72,4 +72,5 @@ public class AuthenticationService {
     ) {
         return roleRepo.findAllByUserId(id);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/auth/SignupService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/auth/SignupService.java
@@ -10,14 +10,15 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
-/**
- * 회원 가입 서비스
- */
+/** 회원 가입 서비스 */
 @Service
 @Slf4j
 public class SignupService {
+    
     private final PasswordEncoder passwordEncoder;
+    
     private final UserRepository userRepo;
+    
     private final RoleRepository roleRepo;
 
     public SignupService(
@@ -59,4 +60,5 @@ public class SignupService {
         
         return user;
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationAddService.java
@@ -17,13 +17,13 @@ import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
-/**
- * 좌석 예약 서비스
- */
+/** 예약 추가 서비스 */
 @Service
 @Slf4j
 public class ReservationAddService {
+    
     private final PlanRepository planRepo;
+    
     private final ReservationRepository reservationRepo;
 
     public ReservationAddService(
@@ -85,7 +85,10 @@ public class ReservationAddService {
      * @param userId 회원 id
      * @return 중복된 예약이면 true, 그렇지 않으면 false
      */
-    public boolean isDuplicateReservation(Date date, Long userId) {
+    public boolean isDuplicateReservation(
+            Date date, 
+            Long userId
+    ) {
         return reservationRepo.existsByDateAndUser_IdAndStatusNot(date, userId, ReservationStatus.CANCELED);
     }
 
@@ -96,7 +99,9 @@ public class ReservationAddService {
      * @return 조회된 예약
      * @throws ReservationNotFoundException 예약 조회에 실패하면 던집니다.
      */
-    public Reservation findReservation(Long id) {
+    public Reservation findReservation(
+            Long id
+    ) {
         return reservationRepo.findById(id)
                 .orElseThrow(() -> new ReservationNotFoundException());
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationCancelService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationCancelService.java
@@ -7,16 +7,16 @@ import com.codesoom.myseat.repositories.ReservationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-/**
- * 좌석 예약 취소 서비스
- */
+/** 예약 취소 서비스 */
 @Service
 @Slf4j
 public class ReservationCancelService {
 
     private final ReservationRepository repository;
 
-    public ReservationCancelService(ReservationRepository repository) {
+    public ReservationCancelService(
+            ReservationRepository repository
+    ) {
         this.repository = repository;
     }
 
@@ -28,7 +28,10 @@ public class ReservationCancelService {
      * @throws ReservationNotFoundException 주어진 예약 id로 예약을 찾지 못한 경우
      * @throws NotOwnedReservationException 요청한 회원의 소유한 예약이 아닌 경우
      */
-    public void cancelReservation(Long userId, Long id) {
+    public void cancelReservation(
+            Long userId, 
+            Long id
+    ) {
         Reservation reservation = repository.findById(id)
                 .orElseThrow(ReservationNotFoundException::new);
         if (!reservation.isOwnReservation(userId)) {

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
@@ -14,7 +14,9 @@ public class ReservationDetailService {
 
     private final ReservationRepository repository;
 
-    public ReservationDetailService(ReservationRepository repository) {
+    public ReservationDetailService(
+            ReservationRepository repository
+    ) {
         this.repository = repository;
     }
 
@@ -27,7 +29,10 @@ public class ReservationDetailService {
      * @throws ReservationNotFoundException 예약 정보를 찾지 못한 경우 던짐
      */
     @Transactional(readOnly = true)
-    public Reservation reservation(Long reservationId, Long userId) {
+    public Reservation reservation(
+            Long reservationId, 
+            Long userId
+    ) {
         return repository.findByIdAndUser_Id(reservationId, userId)
                 .orElseThrow(ReservationNotFoundException::new);
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationListService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationListService.java
@@ -13,7 +13,9 @@ public class ReservationListService {
     
     private final ReservationRepository repository;
 
-    public ReservationListService(ReservationRepository repository) {
+    public ReservationListService(
+            ReservationRepository repository
+    ) {
         this.repository = repository;
     }
 
@@ -24,7 +26,9 @@ public class ReservationListService {
      * @return 해당 유저의 모든 예약 목록
      */
     @Transactional(readOnly = true)
-    public List<Reservation> reservations(Long userId) {
+    public List<Reservation> reservations(
+            Long userId
+    ) {
         return repository.findAllByUser_IdOrderByDateDesc(userId);
     }
     

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationUpdateService.java
@@ -12,13 +12,15 @@ import com.codesoom.myseat.repositories.ReservationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** 예약 수정 담당 */
+/** 예약 수정 서비스 */
 @Service
 public class ReservationUpdateService {
 
     private final ReservationRepository repository;
 
-    public ReservationUpdateService(ReservationRepository repository) {
+    public ReservationUpdateService(
+            ReservationRepository repository
+    ) {
         this.repository = repository;
     }
 
@@ -34,7 +36,11 @@ public class ReservationUpdateService {
      * @throws CannotUpdateCanceledReservationException 취소된 예약을 수정하려고 하면 던집니다.
      */
     @Transactional
-    public void updateReservation(Long userId, Long id, ReservationRequest request) {
+    public void updateReservation(
+            Long userId, 
+            Long id, 
+            ReservationRequest request
+    ) {
         Reservation reservation = repository.findById(id)
                 .orElseThrow(ReservationNotFoundException::new);
         Date date = new Date(request.getDate());
@@ -62,7 +68,10 @@ public class ReservationUpdateService {
      * @param userId 회원 id
      * @return 기록이 있으면 true, 없으면 false
      */
-    private boolean hasSameDateReservation(Date date, Long userId) {
+    private boolean hasSameDateReservation(
+            Date date, 
+            Long userId
+    ) {
         return repository.existsByDateAndUser_Id(date, userId);
     }
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddService.java
@@ -17,9 +17,13 @@ import org.springframework.stereotype.Service;
 public class RetrospectiveAddService {
 
     private final RetrospectiveRepository retrospectiveRepository;
+    
     private final ReservationRepository reservationRepository;
 
-    public RetrospectiveAddService(RetrospectiveRepository retrospectiveRepository, ReservationRepository reservationRepository) {
+    public RetrospectiveAddService(
+            RetrospectiveRepository retrospectiveRepository, 
+            ReservationRepository reservationRepository
+    ) {
         this.retrospectiveRepository = retrospectiveRepository;
         this.reservationRepository = reservationRepository;
     }
@@ -34,9 +38,11 @@ public class RetrospectiveAddService {
      * @throws NotOwnedReservationException 예약자가 아닌 회원이 해당 예약에 대해 회고를 작성하려고 한다면 예외를 던집니다.
      * @throws ContentTooLongException 회고의 길이가 너무 길면 던집니다.
      */
-    public Retrospective createRetrospective(final User user,
-                                             final Long reservationId,
-                                             final String content) {
+    public Retrospective createRetrospective(
+            final User user, 
+            final Long reservationId, 
+            final String content
+    ) {
         if (!isReservedUser(reservationId, user.getId())) {
             throw new NotOwnedReservationException();
         }
@@ -69,8 +75,11 @@ public class RetrospectiveAddService {
      * @param userId 회원 id
      * @return 예약한 회원이면 true, 그렇지 않으면 false
      */
-    public boolean isReservedUser(final Long reservationId,
-                                  final Long userId) {
+    public boolean isReservedUser(
+            final Long reservationId, 
+            final Long userId
+    ) {
         return reservationRepository.existsByIdAndUser_Id(reservationId, userId);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveDetailService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class RetrospectiveDetailService {
+    
     private final RetrospectiveRepository retrospectiveRepo;
 
     public RetrospectiveDetailService(
@@ -30,4 +31,5 @@ public class RetrospectiveDetailService {
         return retrospectiveRepo.findByReservationId(id)
                 .orElseThrow(() -> new RetrospectiveNotFoundException());
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveUpdateService.java
@@ -14,7 +14,9 @@ public class RetrospectiveUpdateService {
 
     private final ReservationRepository reservationRepository;
 
-    public RetrospectiveUpdateService(ReservationRepository reservationRepository) {
+    public RetrospectiveUpdateService(
+            ReservationRepository reservationRepository
+    ) {
         this.reservationRepository = reservationRepository;
     }
 
@@ -27,10 +29,13 @@ public class RetrospectiveUpdateService {
      * @throws NotOwnedReservationException 회원이 해당 예약을 소유하지 않는 경우
      */
     @Transactional
-    public void update(final Long reservationId,
-                       final User user,
-                       final String content) {
-        Reservation reservation = reservationRepository.findByIdAndUser_Id(reservationId, user.getId())
+    public void update(
+            final Long reservationId, 
+            final User user, 
+            final String content
+    ) {
+        Reservation reservation 
+                = reservationRepository.findByIdAndUser_Id(reservationId, user.getId())
                 .orElseThrow(NotOwnedReservationException::new);
 
         reservation.updateRetrospective(content);

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/users/UserService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class UserService {
+    
     private final UserRepository userRepo;
 
     public UserService(
@@ -54,7 +55,10 @@ public class UserService {
      * @param email 이메일
      * @return 이미 가입된 이메일이면 true, 그렇지 않으면 false
      */
-    public Boolean isDuplicatedEmail(String email) {
+    public Boolean isDuplicatedEmail(
+            String email
+    ) {
         return userRepo.existsByEmail(email);
     }
+    
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/utils/JwtUtil.java
@@ -17,6 +17,7 @@ import java.util.Date;
 @Slf4j
 @Component
 public class JwtUtil {
+    
     private final Key key;
 
     public JwtUtil(
@@ -31,7 +32,9 @@ public class JwtUtil {
      * @param id 토큰을 부여할 회원의 id
      * @return 토큰 
      */
-    public String makeAccessToken(Long id) {
+    public String makeAccessToken(
+            Long id
+    ) {
         Date now = new Date();
 
         return Jwts.builder()
@@ -50,7 +53,9 @@ public class JwtUtil {
      * @param accessToken
      * @return 이메일
      */
-    public Long parseAccessToken(String accessToken) {
+    public Long parseAccessToken(
+            String accessToken
+    ) {
         log.info("accessToken: " + accessToken);
 
         try {
@@ -66,4 +71,5 @@ public class JwtUtil {
             throw new InvalidTokenException();
         }
     }
+    
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/auth/AuthenticationServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/auth/AuthenticationServiceTest.java
@@ -2,8 +2,6 @@ package com.codesoom.myseat.services.auth;
 
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.repositories.RoleRepository;
-import com.codesoom.myseat.repositories.UserRepository;
-import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.utils.JwtUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,9 +26,6 @@ class AuthenticationServiceTest {
 
     private AuthenticationService authService;
 
-    private final UserRepository userRepo 
-            = mock(UserRepository.class);
-
     private final RoleRepository roleRepo 
             = mock(RoleRepository.class);
 
@@ -43,7 +38,6 @@ class AuthenticationServiceTest {
     @BeforeEach
     void setUp() {
         authService = new AuthenticationService(
-                userRepo,
                 roleRepo,
                 jwtUtil,
                 passwordEncoder


### PR DESCRIPTION
불필요한 주석을 제거하고, 코드 스타일을 통일시켰습니다.(내부 로직에는 변경 사항이 없습니다.)

- 기존에는 내용이 한 줄인 Javadoc도 아래와 같이 썼었는데,
```
/**
 ~~~
*/
```
이를 한 줄로 수정했습니다.
```
/** ~~~ */
```

- 파라미터가 여러개이거나 파라미터명이 너무 긴 것들은 괄호 내에서 개행시켰습니다.
- 클래스 시작 중괄호 다음에 개행을 추가하고, 끝 중괄호 전에 개행을 추가했습니다.
- extends나 implements 앞에 개행을 추가했습니다.