### PR TITLE
admin의 모든 예약 목록을 조회하는 API를 추가하라 

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.codesoom.myseat.filters.AuthenticationFilter;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -18,6 +19,7 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final AuthenticationService authService;
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/AdminReservationListController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/AdminReservationListController.java
@@ -1,0 +1,46 @@
+package com.codesoom.myseat.controllers.admin.reservations;
+
+import com.codesoom.myseat.dto.ReservationListResponse;
+import com.codesoom.myseat.dto.ReservationResponse;
+import com.codesoom.myseat.security.UserAuthentication;
+import com.codesoom.myseat.services.reservations.ReservationListService;
+import com.codesoom.myseat.services.users.UserService;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.stream.Collectors;
+
+/**
+ * 예약 목록 조회 컨트롤러
+ */
+@CrossOrigin
+@RequestMapping("/admin/reservations")
+@RestController
+public class AdminReservationListController {
+    private final ReservationListService service;
+
+    public AdminReservationListController(ReservationListService service) {
+        this.service = service;
+    }
+
+    /**
+     * 모든 회원의 예약 목록을 조회합니다.
+     *
+     * @return 모든 예약 정보
+     */
+    @PreAuthorize("isAuthenticated() and hasAuthority('ADMIN')")
+    @GetMapping
+    public ReservationListResponse reservations() {
+        return new ReservationListResponse(
+                service.allReservations()
+                        .stream()
+                        .map(ReservationResponse::new)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationListService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationListService.java
@@ -27,5 +27,13 @@ public class ReservationListService {
     public List<Reservation> reservations(Long userId) {
         return repository.findAllByUser_IdOrderByDateDesc(userId);
     }
-    
+
+    /**
+     * 예약 목록을 조회합니다.
+     *
+     * @return 모든 유저의 예약 목록
+     */
+    public List<Reservation> allReservations() {
+        return repository.findAll();
+    }
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationListControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationListControllerTest.java
@@ -1,0 +1,96 @@
+package com.codesoom.myseat.controllers.admin.reservations;
+
+import com.codesoom.myseat.domain.Date;
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationListService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(AdminReservationListController.class)
+class AdminReservationListControllerTest {
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+    Role USER_ROLE = new Role(1L, 1L, "USER");
+    Role ADMIN_ROLE = new Role(1L, 1L, "ADMIN");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private ReservationListService reservationListService;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .build();
+    }
+
+    @DisplayName("GET /admin/reservations을 admin인 사람이 요청하면 " +
+            "예약 목록을 응답합니다.")
+    @Test
+    void GET_admin_reservations_responses_all_reservations() throws Exception {
+        given(authService.roles(any())).willReturn(List.of(ADMIN_ROLE));
+
+        String content = "코테풀기, 공부, 과제";
+        given(reservationListService.allReservations())
+                .willReturn(List.of(
+                        Reservation.builder()
+                                .id(1L)
+                                .plan(Plan.builder().id(1L).content(content).build())
+                                .date(new Date("2022-10-13"))
+                                .build()
+                ));
+
+
+        mockMvc.perform(get("/admin/reservations")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+        )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reservations[0].content")
+                        .value(content));
+    }
+
+    @DisplayName("GET /admin/reservations을 admin이 아닌 사람이 요청하면 " +
+            "403을 응답합니다.")
+    @Test
+    void GET_admin_reservations_responses_403() throws Exception {
+        given(authService.roles(any())).willReturn(List.of(USER_ROLE));
+
+        mockMvc.perform(get("/admin/reservations")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN)
+        ).andExpect(status().isForbidden());
+    }
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationListServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationListServiceTest.java
@@ -30,35 +30,40 @@ class ReservationListServiceTest {
     @Mock
     private PlanRepository planRepository;
 
+    private User mockUser;
+    private Reservation mockReservation;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
         service = new ReservationListService(reservationRepository);
     }
 
+    @BeforeEach()
+    void dataSetUp() {
+        mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+        Plan plan = Plan.builder().content("공부").build();
+        mockReservation = Reservation.builder()
+                .user(mockUser)
+                .plan(plan)
+                .date(new Date("2022-10-12"))
+                .build();
+    }
+
     @DisplayName("reservations 메소드는")
     @Nested
-    class Describe_reservations{
+    class Describe_reservations {
 
         @DisplayName("주어진 사용자 정보와 일치하는 모든 예약 목록을 조회한다")
         @Test
         void will_return_reservations() {
-            //given
-            User mockUser = User.builder()
-                    .id(1L)
-                    .name("김철수")
-                    .email("soo@email.com")
-                    .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                    .build();
-            Plan plan = Plan.builder().content("공부").build();
-            Reservation reservation = Reservation.builder()
-                    .user(mockUser)
-                    .plan(plan)
-                    .date(new Date("2022-10-12"))
-                    .build();
-
             given(reservationRepository.findAllByUser_IdOrderByDateDesc(same(1L)))
-                    .willReturn(List.of(reservation));
+                    .willReturn(List.of(mockReservation));
 
             //when
             List<Reservation> reservations = service.reservations(mockUser.getId());
@@ -68,5 +73,24 @@ class ReservationListServiceTest {
             assertThat(reservations.get(0).getUser().getId()).isEqualTo(mockUser.getId());
         }
     }
-    
+
+    @DisplayName("allReservations 메소드는")
+    @Nested
+    class Describe_allReseravtions {
+        @BeforeEach()
+        void setUp() {
+            given(reservationRepository.findAll())
+                    .willReturn(List.of(mockReservation));
+        }
+
+        @DisplayName("모든 예약 목록을 반환한다")
+        @Test
+        void it_returns_all_reservations() {
+            List<Reservation> reservations = service.allReservations();
+
+            assertThat(reservations.size()).isEqualTo(1);
+            assertThat(reservations.get(0).getPlan().getContent())
+                    .isEqualTo("공부");
+        }
+    }
 }


### PR DESCRIPTION
Admin은 현재 사용자와 상관없이 모든 예약 목록을 조회할 수 있어야 합니다.
따라서 admin만 할 수 있는 모든 예약 목록 조회 API를 구현합니다.

스프링 시큐리티의 prePostEnabled의 기본값은 false입니다.
그래서 메서드 단위의 인가를 설정할 수 없습니다.
prePostEnabled의 값을 true로 설정하기 위해 SecurityConfig에 `@EnableGlobalMethodSecurity(prePostEnabled = true)`어노테이션을 추가합니다.

See also
  -  https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.html
