### PR TITLE
컨트롤러와 컨트롤러 테스트를 리팩터링하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationCancelController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationCancelController.java
@@ -32,8 +32,9 @@ public class ReservationCancelController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/{id}")
-    public void cancelReservation(@AuthenticationPrincipal UserAuthentication principal,
-                                  @PathVariable Long id) {
+    public void cancelReservation(
+            @AuthenticationPrincipal final UserAuthentication principal,
+            @PathVariable final Long id) {
         log.debug("--------- 예약 취소 요쳥");
         log.debug("예약 id: {}", id);
         cancelService.cancelReservation(principal.getId(), id);

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
@@ -24,14 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ReservationDetailController {
     
-    private final UserService userService;
     private final ReservationDetailService service;
 
     public ReservationDetailController(
-            UserService userService, 
             ReservationDetailService service
     ) {
-        this.userService = userService;
         this.service = service;
     }
 
@@ -47,12 +44,11 @@ public class ReservationDetailController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{id}")
     public ReservationResponse reservation(
-            @AuthenticationPrincipal UserAuthentication principal, 
-            @PathVariable(name = "id") Long reservationId
+            @AuthenticationPrincipal final UserAuthentication principal,
+            @PathVariable(name = "id") final Long reservationId
     ) {
-        User user = userService.findById(principal.getId());
-
-        return new ReservationResponse(service.reservation(reservationId, user.getId()));
+        return new ReservationResponse(
+                service.reservation(reservationId, principal.getId()));
     }
     
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationListController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationListController.java
@@ -1,6 +1,5 @@
 package com.codesoom.myseat.controllers.reservations;
 
-import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationListResponse;
 import com.codesoom.myseat.dto.ReservationResponse;
 import com.codesoom.myseat.security.UserAuthentication;
@@ -25,11 +24,9 @@ import java.util.stream.Collectors;
 @RestController
 public class ReservationListController {
 
-    private final UserService userService;
     private final ReservationListService service;
 
-    public ReservationListController(UserService userService, ReservationListService service) {
-        this.userService = userService;
+    public ReservationListController(ReservationListService service) {
         this.service = service;
     }
 
@@ -42,11 +39,10 @@ public class ReservationListController {
     @PreAuthorize("isAuthenticated()")
     @ResponseStatus(HttpStatus.OK)
     @GetMapping
-    public ReservationListResponse reservations(@AuthenticationPrincipal UserAuthentication principal) {
-        User user = userService.findById(principal.getId());
-
+    public ReservationListResponse reservations(
+            @AuthenticationPrincipal final UserAuthentication principal) {
         return new ReservationListResponse(
-                service.reservations(user.getId())
+                service.reservations(principal.getId())
                 .stream()
                 .map(ReservationResponse::new)
                 .collect(Collectors.toList())

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationAddControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationAddControllerTest.java
@@ -3,37 +3,52 @@ package com.codesoom.myseat.controllers.reservations;
 import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Role;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationRequest;
 import com.codesoom.myseat.enums.ReservationStatus;
 import com.codesoom.myseat.exceptions.AlreadyReservedException;
 import com.codesoom.myseat.exceptions.NotReservableDateException;
+import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationAddService;
 import com.codesoom.myseat.services.users.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ReservationAddController.class)
 class ReservationAddControllerTest {
+
     private static final String ACCESS_TOKEN 
             = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
 
@@ -48,6 +63,17 @@ class ReservationAddControllerTest {
     
     @MockBean
     private ReservationAddService reservationAddService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    final Long USER_ID = 1L;
+    final User MOCK_USER = User.builder()
+            .id(USER_ID)
+            .name("김철수")
+            .email("soo@email.com")
+            .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+            .build();
 
     Date getReservableDate() {
         long plusDays = 0;
@@ -66,107 +92,82 @@ class ReservationAddControllerTest {
         return new Date(notReservableDate.format(dateFormat));
     }
 
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter(
+                        "UTF-8", true))
+                .defaultRequest(
+                        post("/reservations")
+                                .header(HttpHeaders.AUTHORIZATION,
+                                        "Bearer " + ACCESS_TOKEN))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+    }
+
     @Test
     @DisplayName("POST /reservations 요청 시 상태코드 204를 응답한다")
     void POST_reservations_responses_status_code_204() throws Exception {
         Date date = getReservableDate();
-        User mockUser = User.builder()
-                .id(1L)
-                .name("김철수")
-                .email("soo@email.com")
-                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                .build();
-        
-        given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(1L);
-        
-        given(userService.findById(1L))
-                .willReturn(mockUser);
 
         ReservationRequest request = ReservationRequest.builder()
                 .date(date.getDate())
                 .content("책읽기, 코테풀기")
                 .build();
 
-        given(reservationAddService.createReservation(mockUser, date.getDate(), "책읽기, 코테풀기"))
+        given(reservationAddService.createReservation(MOCK_USER,
+                date.getDate(),
+                "책읽기, 코테풀기"))
                 .willReturn(Reservation.builder()
-                        .user(mockUser)
+                        .user(MOCK_USER)
                         .plan(Plan.builder().content("책읽기, 코테풀기").build())
                         .date(date)
                         .status(ReservationStatus.RESERVED)
                         .build());
 
-        ResultActions result =  mockMvc.perform(post("/reservations")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(request)));
-
-        result.andExpect(status().isNoContent());
+        mockMvc.perform(post("/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
+                .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("이미 예약 내역이 존재하는 방문 일자가 주어지면 상태코드 400을 응답한다")
-    void If_already_existing_date_given_it_responses_status_code_400() throws Exception {
+    void If_already_existing_date_given_it_responses_status_code_400()
+            throws Exception {
+
         Date date = getReservableDate();
-        User mockUser = User.builder()
-                .id(1L)
-                .name("김철수")
-                .email("soo@email.com")
-                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                .build();
-
-        given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(1L);
-
-        given(userService.findById(1L))
-                .willReturn(mockUser);
-
-        given(reservationAddService.createReservation(mockUser, date.getDate(), "책읽기, 코테풀기"))
-                .willThrow(AlreadyReservedException.class);
-
         ReservationRequest request = ReservationRequest.builder()
                 .date(date.getDate())
                 .content("책읽기, 코테풀기")
                 .build();
 
-        ResultActions result = mockMvc.perform(post("/reservations")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(request)));
+        given(reservationAddService.createReservation(any(), any(), any()))
+                .willThrow(AlreadyReservedException.class);
 
-        result.andExpect(status().isBadRequest());
+        mockMvc.perform(post("/reservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("예약이 불가능한 날짜가 주어지면 상태코드 400을 응답한다")
-    void If_not_reservable_date_given_it_responses_status_code_400() throws Exception {
+    void If_not_reservable_date_given_it_responses_status_code_400()
+            throws Exception {
         Date notReservableDate = getNotReservableDate();
-        User mockUser = User.builder()
-                .id(1L)
-                .name("김철수")
-                .email("soo@email.com")
-                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                .build();
-
-        given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(1L);
-
-        given(userService.findById(1L))
-                .willReturn(mockUser);
-
-        given(reservationAddService.createReservation(mockUser,notReservableDate.getDate(), "책읽기, 코테풀기"))
-                .willThrow(NotReservableDateException.class);
-
         ReservationRequest request = ReservationRequest.builder()
                 .date(notReservableDate.getDate())
                 .content("책읽기, 코테풀기")
                 .build();
+        given(reservationAddService.createReservation(
+                any(), anyString(), anyString()))
+                .willThrow(NotReservableDateException.class);
 
         ResultActions result = mockMvc.perform(post("/reservations")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(toJson(request)));
-
         result.andExpect(status().isBadRequest());
     }
 

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationCancelControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationCancelControllerTest.java
@@ -1,11 +1,9 @@
 package com.codesoom.myseat.controllers.reservations;
 
-import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationCancelService;
-import com.codesoom.myseat.services.users.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +19,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -42,9 +39,6 @@ class ReservationCancelControllerTest {
     private AuthenticationService authService;
 
     @MockBean
-    private UserService userService;
-
-    @MockBean
     private ReservationCancelService reservationCancelService;
 
     @Autowired
@@ -53,30 +47,21 @@ class ReservationCancelControllerTest {
     @BeforeEach
     void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .addFilters(new CharacterEncodingFilter(
+                        "UTF-8", true))
+                .defaultRequest(
+                        patch("/reservations/*")
+                                .header(HttpHeaders.AUTHORIZATION,
+                                        "Bearer " + ACCESS_TOKEN))
                 .apply(springSecurity())
                 .alwaysDo(print())
                 .build();
-
-        User mockUser = User.builder()
-                .id(1L)
-                .name("김철수")
-                .email("soo@email.com")
-                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                .build();
-
-        given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(1L);
-
-        given(userService.findById(1L))
-                .willReturn(mockUser);
     }
 
     @DisplayName("예약을 성공적으로 취소하면 204 no content를 응답한다.")
     @Test
     void PUT_reservation_cancel_with_204_status() throws Exception {
-        mockMvc.perform(patch("/reservations/1")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
+        mockMvc.perform(patch("/reservations/1"))
                 .andExpect(status().isNoContent());
     }
 
@@ -87,8 +72,7 @@ class ReservationCancelControllerTest {
                 .when(reservationCancelService)
                 .cancelReservation(anyLong(), anyLong());
 
-        mockMvc.perform(patch("/reservations/999")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
+        mockMvc.perform(patch("/reservations/999"))
                 .andExpect(status().isForbidden());
     }
 
@@ -99,8 +83,8 @@ class ReservationCancelControllerTest {
                 .when(reservationCancelService)
                 .cancelReservation(anyLong(), anyLong());
 
-        mockMvc.perform(patch("/reservations/999")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
+        mockMvc.perform(patch("/reservations/999"))
                 .andExpect(status().isNotFound());
     }
+
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationListControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationListControllerTest.java
@@ -3,7 +3,9 @@ package com.codesoom.myseat.controllers.reservations;
 import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Role;
 import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationListService;
 import com.codesoom.myseat.services.users.UserService;
@@ -15,6 +17,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithSecurityContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -26,14 +32,19 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ReservationListController.class)
 class ReservationListControllerTest {
+
     private static final String ACCESS_TOKEN
             = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
 
@@ -55,24 +66,15 @@ class ReservationListControllerTest {
     @BeforeEach
     void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-                .addFilters(new CharacterEncodingFilter("UTF-8", true))
+                .addFilters(
+                        new CharacterEncodingFilter(
+                                "UTF-8", true))
+                .defaultRequest(get("/reservations")
+                        .header(HttpHeaders.AUTHORIZATION,
+                                "Bearer " + ACCESS_TOKEN))
                 .apply(springSecurity())
                 .alwaysDo(print())
                 .build();
-
-        //given
-        User mockUser = User.builder()
-                .id(1L)
-                .name("김철수")
-                .email("soo@email.com")
-                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
-                .build();
-
-        given(authService.parseToken(ACCESS_TOKEN))
-                .willReturn(1L);
-
-        given(userService.findById(1L))
-                .willReturn(mockUser);
     }
 
     @DisplayName("요청한 유저의 모든 예약 목록을 응답한다.")
@@ -80,18 +82,20 @@ class ReservationListControllerTest {
     void GET_reservations_with_200_status() throws Exception {
         //given
         String content = "코테풀기, 공부, 과제";
-        given(reservationListService.reservations(1L))
+        given(reservationListService.reservations(anyLong()))
                 .willReturn(List.of(
                         Reservation.builder()
                                 .id(1L)
-                                .plan(Plan.builder().id(1L).content(content).build())
+                                .plan(Plan.builder()
+                                        .id(1L)
+                                        .content(content)
+                                        .build())
                                 .date(new Date("2022-10-13"))
-                                .build()
-                ));
+                                .build()));
 
         //when
-        ResultActions perform = mockMvc.perform(get("/reservations")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN));
+        ResultActions perform
+                = mockMvc.perform(get("/reservations"));
 
         //then
         MvcResult result = perform.andReturn();


### PR DESCRIPTION
컨트롤러의 userService의존성을 제거하고 principal을 사용합니다.
컨트롤러 테스트의 토큰 검증 로직 목킹을 제거합니다.