### PR TITLE
관리자가 예약 상세를 조회할 수 있도록 하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationDetailController.java
@@ -1,0 +1,39 @@
+package com.codesoom.myseat.controllers.admin.reservations;
+
+import com.codesoom.myseat.dto.ReservationResponse;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
+import com.codesoom.myseat.services.reservations.ReservationDetailService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 관리자 예약 상세 조회 컨트롤러
+ */
+@CrossOrigin
+@RequestMapping("/admin/reservations")
+@RestController
+public class AdminReservationDetailController {
+
+    private final ReservationDetailService service;
+
+    public AdminReservationDetailController(
+            ReservationDetailService service
+    ) {
+        this.service = service;
+    }
+
+    /**
+     * 예약 id로 예약 내용을 상세 조회합니다.
+     *
+     * @return 예약 정보
+     * @throws ReservationNotFoundException 주어진 예약 id로 예약 정보를 찾지 못한 경우
+     */
+    @PreAuthorize("isAuthenticated() and hasAuthority('ADMIN')")
+    @GetMapping("/{id}")
+    public ReservationResponse reservation(
+            @PathVariable(name = "id") Long id
+    ) {
+        return new ReservationResponse(service.reservation(id));
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/ReservationDetailController.java
@@ -1,11 +1,9 @@
 package com.codesoom.myseat.controllers.reservations;
 
-import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.dto.ReservationResponse;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.security.UserAuthentication;
 import com.codesoom.myseat.services.reservations.ReservationDetailService;
-import com.codesoom.myseat.services.users.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/reservations")
 @RestController
 public class ReservationDetailController {
-    
+
     private final ReservationDetailService service;
 
     public ReservationDetailController(
@@ -35,7 +33,7 @@ public class ReservationDetailController {
     /**
      * 예약 id와 회원 id로 예약 내용을 상세 조회합니다.
      *
-     * @param principal 회원 인증 정보
+     * @param principal     회원 인증 정보
      * @param reservationId 예약 id
      * @return 예약 정보
      * @throws ReservationNotFoundException 주어진 예약 id와 회원 id로 예약 정보를 찾지 못한 경우
@@ -48,7 +46,7 @@ public class ReservationDetailController {
             @PathVariable(name = "id") final Long reservationId
     ) {
         return new ReservationResponse(
-                service.reservation(reservationId, principal.getId()));
+                service.reservationOfUser(reservationId, principal.getId()));
     }
-    
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailController.java
@@ -42,7 +42,7 @@ public class RetrospectiveDetailController {
             @AuthenticationPrincipal UserAuthentication principal,
             @PathVariable Long id
     ) {
-        Reservation reservation = reservationDetailService.reservation(id, principal.getId());
+        Reservation reservation = reservationDetailService.reservationOfUser(id, principal.getId());
         Retrospective retrospective = retrospectiveDetailService.retrospective(id);
         
         return toResponse(retrospective);

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
@@ -27,7 +27,7 @@ public class ReservationDetailService {
      * @throws ReservationNotFoundException 예약 정보를 찾지 못한 경우 던짐
      */
     @Transactional(readOnly = true)
-    public Reservation reservation(Long reservationId, Long userId) {
+    public Reservation reservationOfUser(Long reservationId, Long userId) {
         return repository.findByIdAndUser_Id(reservationId, userId)
                 .orElseThrow(ReservationNotFoundException::new);
     }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/ReservationDetailService.java
@@ -7,7 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/** 예약 상세 조회 서비스 */
+/**
+ * 예약 상세 조회 서비스
+ */
 @Slf4j
 @Service
 public class ReservationDetailService {
@@ -29,6 +31,19 @@ public class ReservationDetailService {
     @Transactional(readOnly = true)
     public Reservation reservationOfUser(Long reservationId, Long userId) {
         return repository.findByIdAndUser_Id(reservationId, userId)
+                .orElseThrow(ReservationNotFoundException::new);
+    }
+
+    /**
+     * 주어진 reservation id로 예약 내용을 상세 조회합니다.
+     *
+     * @param reservationId 예약 아이디
+     * @return 주어진 정보로 조회한 예약 정보
+     * @throws ReservationNotFoundException 예약 정보를 찾지 못한 경우 던짐
+     */
+    @Transactional(readOnly = true)
+    public Reservation reservation(Long reservationId) {
+        return repository.findById(reservationId)
                 .orElseThrow(ReservationNotFoundException::new);
     }
 

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationDetailControllerTest.java
@@ -1,0 +1,118 @@
+package com.codesoom.myseat.controllers.admin.reservations;
+
+import com.codesoom.myseat.domain.Date;
+import com.codesoom.myseat.domain.Plan;
+import com.codesoom.myseat.domain.Reservation;
+import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.exceptions.ReservationNotFoundException;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.reservations.ReservationDetailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(AdminReservationDetailController.class)
+class AdminReservationDetailControllerTest {
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+    private static final Role USER_ROLE = new Role(1L, 1L, "USER");
+    private static final Role ADMIN_ROLE = new Role(1L, 1L, "ADMIN");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationService authService;
+
+    @MockBean
+    private ReservationDetailService reservationDetailService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(
+                        new CharacterEncodingFilter(
+                                "UTF-8", true))
+                .defaultRequest(get("/admin/reservations/*")
+                        .header(HttpHeaders.AUTHORIZATION,
+                                "Bearer " + ACCESS_TOKEN))
+                .apply(springSecurity())
+                .build();
+    }
+
+    @DisplayName("GET /admin/reservation/{id}는 예약 정보를 응답합니다.")
+    @Test
+    void GET_reservation_responses_reservation() throws Exception {
+        Long reservationId = 1L;
+        String content = "코테풀기, 공부, 과제";
+
+        given(authService.roles(any())).willReturn(List.of(ADMIN_ROLE));
+
+        given(reservationDetailService.reservation(reservationId))
+                .willReturn(Reservation.builder()
+                        .id(reservationId)
+                        .plan(Plan.builder().id(1L).content(content).build())
+                        .date(new Date("2022-10-13"))
+                        .build());
+
+        ResultActions perform
+                = mockMvc.perform(
+                        get("/admin/reservations/" + reservationId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value(content));
+    }
+
+    @DisplayName("GET /admin/reservation/{id}는 존재하지 않은 예약을 조회하면 " +
+            "404를 응답합니다")
+    @Test
+    void GET_reservation_with_not_exists_responses_404() throws Exception {
+        Long reservationId = 1L;
+
+        given(authService.roles(any())).willReturn(List.of(ADMIN_ROLE));
+
+        given(reservationDetailService.reservation(reservationId))
+                .willThrow(ReservationNotFoundException.class);
+
+        ResultActions perform
+                = mockMvc.perform(
+                        get("/admin/reservations/" + reservationId))
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("GET /admin/reservation/{id}는 관리자 권한이 없는 사용자가 " +
+            "요청하면 403을 응답합니다")
+    @Test
+    void GET_reservation_with_not_admin_responses_403() throws Exception {
+        given(authService.roles(any())).willReturn(List.of(USER_ROLE));
+
+        ResultActions perform
+                = mockMvc.perform(get("/admin/reservations/1"))
+                .andExpect(status().isForbidden());
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/ReservationDetailControllerTest.java
@@ -3,7 +3,6 @@ package com.codesoom.myseat.controllers.reservations;
 import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
-import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.InvalidTokenException;
 import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.services.auth.AuthenticationService;
@@ -26,7 +25,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -76,7 +74,7 @@ class ReservationDetailControllerTest {
         //given
         Long reservationId = 1L;
         String content = "코테풀기, 공부, 과제";
-        given(reservationDetailService.reservation(anyLong(), anyLong()))
+        given(reservationDetailService.reservationOfUser(anyLong(), anyLong()))
                 .willReturn(Reservation.builder()
                         .id(reservationId)
                         .plan(Plan.builder().id(1L).content(content).build())
@@ -86,7 +84,7 @@ class ReservationDetailControllerTest {
         //when
         ResultActions perform
                 = mockMvc.perform(get(
-                        String.format("/reservations/%d", reservationId)));
+                String.format("/reservations/%d", reservationId)));
 
         //then
         MvcResult result = perform.andReturn();
@@ -99,13 +97,12 @@ class ReservationDetailControllerTest {
     void GET_reservation_with_404_status() throws Exception {
         //given
         Long notExistReservationId = 100L;
-        given(reservationDetailService.reservation(
-                eq(notExistReservationId), anyLong()))
+        given(reservationDetailService.reservationOfUser(eq(notExistReservationId), anyLong()))
                 .willThrow(ReservationNotFoundException.class);
 
         //when & then
         mockMvc.perform(get(
-                String.format("/reservations/%d", notExistReservationId)))
+                        String.format("/reservations/%d", notExistReservationId)))
                 .andExpect(status().isNotFound());
     }
 
@@ -114,6 +111,7 @@ class ReservationDetailControllerTest {
     void GET_reservation_with_401_status() throws Exception {
         //given
         Long reservationId = 1L;
+
         given(authService.parseToken(anyString()))
                 .willThrow(new InvalidTokenException());
 
@@ -123,5 +121,5 @@ class ReservationDetailControllerTest {
                                 "Bearer " + "akdjfisdlkfajsdlk"))
                 .andExpect(status().isUnauthorized());
     }
-    
+
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveDetailControllerTest.java
@@ -82,7 +82,7 @@ class RetrospectiveDetailControllerTest {
         given(userService.findById(1L))
                 .willReturn(mockUser);
         
-        given(reservationDetailService.reservation(3L, 1L))
+        given(reservationDetailService.reservationOfUser(3L, 1L))
                 .willReturn(mockReservation);
         
         given(retrospectiveDetailService.retrospective(3L))

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationDetailServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/ReservationDetailServiceTest.java
@@ -67,7 +67,7 @@ class ReservationDetailServiceTest {
                                 .build()));
 
                 //when
-                Reservation reservation = service.reservation(1L, 1L);
+                Reservation reservation = service.reservationOfUser(1L, 1L);
 
                 //then
                 assertThat(reservation).isNotNull();
@@ -88,7 +88,7 @@ class ReservationDetailServiceTest {
 
                 //when & then
                 assertThrows(ReservationNotFoundException.class,
-                        ()-> service.reservation(100L, 100L));
+                        ()-> service.reservationOfUser(100L, 100L));
             }
         }
     }


### PR DESCRIPTION
사용자가 예약 상세를 조회하는 API는 사용자 정보를 필요로 합니다.
관리자는 어떤 사용자든 조회할 수 있으므로 덜 구체적인 API입니다. 따라서
사용자의 아이디로 조회하는 API는 더 구체적인 resevationOfUser라는
이름으로 변경합니다.

관리자가 예약 id로 상세 조회를 할 수 있도록 `/admin/reservaions/{id}`를 추가합니다.
