### PR TITLE
관리자 예약 목록에 사용자 정보를 추가적으로 포함시켜라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminReservationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminReservationResponse.java
@@ -1,0 +1,28 @@
+package com.codesoom.myseat.dto;
+
+import com.codesoom.myseat.domain.Reservation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 예약 조회 응답 정보
+ */
+@Getter
+@NoArgsConstructor
+public class AdminReservationResponse {
+
+    private Long id;
+    private String date;
+    private String content;
+    private String status;
+    private UserResponse user;
+
+    public AdminReservationResponse(Reservation reservation) {
+        this.id = reservation.getId();
+        this.date = reservation.getDate().getDate();
+        this.content = reservation.getPlan().getContent();
+        this.status = reservation.getStatus().name();
+        this.user = new UserResponse(reservation.getUser());
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminReservationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminReservationResponse.java
@@ -4,9 +4,7 @@ import com.codesoom.myseat.domain.Reservation;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 예약 조회 응답 정보
- */
+/** 예약 조회 응답 정보 */
 @Getter
 @NoArgsConstructor
 public class AdminReservationResponse {

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListPageResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/ReservationListPageResponse.java
@@ -8,17 +8,19 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/** 예약 목록 조회 응답 정보 */
+/**
+ * 예약 목록 조회 응답 정보
+ */
 @NoArgsConstructor
 @Getter
 public class ReservationListPageResponse {
 
-    private List<ReservationResponse> reservations;
+    private List<AdminReservationResponse> reservations;
     private Pagination pagination;
 
     public ReservationListPageResponse(Page<Reservation> pageReservation) {
         this.reservations = pageReservation.getContent().stream()
-                .map(ReservationResponse::new)
+                .map(AdminReservationResponse::new)
                 .collect(Collectors.toList());
         this.pagination = new Pagination(
                 pageReservation.getNumber(),

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/UserResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/UserResponse.java
@@ -4,9 +4,7 @@ import com.codesoom.myseat.domain.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 예약 정보에 포함되는 사용자 정보
- */
+/** 예약 정보에 포함되는 사용자 정보 */
 @Getter
 @NoArgsConstructor
 public class UserResponse {

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/UserResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/UserResponse.java
@@ -1,0 +1,22 @@
+package com.codesoom.myseat.dto;
+
+import com.codesoom.myseat.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 예약 정보에 포함되는 사용자 정보
+ */
+@Getter
+@NoArgsConstructor
+public class UserResponse {
+
+    private Long id;
+    private String name;
+
+    public UserResponse(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationListControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/AdminReservationListControllerTest.java
@@ -4,6 +4,7 @@ import com.codesoom.myseat.domain.Date;
 import com.codesoom.myseat.domain.Plan;
 import com.codesoom.myseat.domain.Reservation;
 import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.reservations.ReservationListService;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,12 +52,21 @@ class AdminReservationListControllerTest {
     @MockBean
     private ReservationListService reservationListService;
 
+    User user;
+
     @BeforeEach
     void setUp() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .addFilters(new CharacterEncodingFilter("UTF-8", true))
                 .apply(springSecurity())
                 .build();
+
+        this.user = new User(
+                1L,
+                "홍길동",
+                "test@email.com",
+                "password"
+        );
     }
 
     @DisplayName("GET /admin/reservations을 admin인 사람이 요청하면 " +
@@ -73,6 +83,7 @@ class AdminReservationListControllerTest {
                                                 .id(1L)
                                                 .plan(Plan.builder().id(1L).content(content).build())
                                                 .date(new Date("2022-10-13"))
+                                                .user(this.user)
                                                 .build()
                                 ),
                                 PageRequest.of(1, 10),
@@ -86,6 +97,8 @@ class AdminReservationListControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.reservations[0].content")
                         .value(content))
+                .andExpect(jsonPath("$.reservations[0].user.name")
+                        .value(this.user.getName()))
                 .andExpect(jsonPath("$.pagination.page")
                         .value(1))
                 .andExpect(jsonPath("$.pagination.size")


### PR DESCRIPTION
관리자가 조회하는 예약 목록에 사용자 정보를 같이 응답하도록 응답 데이터에 사용자 정보를 추가합니다.
그러기 위해서는 관리자 예약 목록 조회에서는 사용자가 조회하는 것과 달리 사용자 정보가 포함되어 있어야 합니다.
따라서 예약 목록 안에 사용자가 포함되어 있는 응답 객체를 정의합니다.
예약 정보에 사용자 정보가 포함되어야 합니다. 사용자 정보를 응답할 수 있도록 UserResponse객체를 정의합니다.