### PR TITLE
이메일 인증 요청을 구현하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/verification/email/EmailVerificationController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/verification/email/EmailVerificationController.java
@@ -1,0 +1,35 @@
+package com.codesoom.myseat.controllers.verification.email;
+
+import com.codesoom.myseat.dto.EmailVerificationResponse;
+import com.codesoom.myseat.security.UserAuthentication;
+import com.codesoom.myseat.services.verification.email.EmailVerificationRequestService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 이메일 인증 요청 컨트롤러 */
+@CrossOrigin
+@RequestMapping("/verification/email")
+@RestController
+public class EmailVerificationController {
+
+    private final EmailVerificationRequestService service;
+
+    public EmailVerificationController(
+            final EmailVerificationRequestService service) {
+        this.service = service;
+    }
+
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @PostMapping
+    public EmailVerificationResponse requestEmailVerification(
+            @AuthenticationPrincipal UserAuthentication principal) {
+        return new EmailVerificationResponse(
+                service.requestEmailVerification(principal.getId()));
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/EmailVerificationResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/EmailVerificationResponse.java
@@ -1,0 +1,22 @@
+package com.codesoom.myseat.dto;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+/** 이메일 인증 요청에 대한 응답 데이터 */
+public class EmailVerificationResponse {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss",
+            timezone = "Asia/Seoul")
+    private final LocalDateTime expirationDate;
+
+    private final int expirationMinutes = 10;
+
+    public EmailVerificationResponse(final EmailToken emailToken) {
+        this.expirationDate = emailToken.getExpirationDate();
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/verification/email/EmailVerificationRequestService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/verification/email/EmailVerificationRequestService.java
@@ -1,0 +1,30 @@
+package com.codesoom.myseat.services.verification.email;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.codesoom.myseat.repositories.EmailTokenRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/** 이메일 인증 요청 서비스 */
+@Service
+public class EmailVerificationRequestService {
+
+    private final EmailTokenRepository repository;
+
+    public EmailVerificationRequestService(
+            final EmailTokenRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 유저 id가 주어지면 해당 유저의 이메일 인증 토큰을 생성해 저장합니다.
+     *
+     * @return 생성된 이메일 인증 토큰
+     */
+    @Transactional
+    public EmailToken requestEmailVerification(Long userId) {
+        return repository.save(EmailToken.createEmailToken(userId));
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/EmailVerificationControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/EmailVerificationControllerTest.java
@@ -1,0 +1,72 @@
+package com.codesoom.myseat.controllers.verification.email;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.verification.email.EmailVerificationRequestService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(EmailVerificationController.class)
+class EmailVerificationControllerTest {
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @MockBean
+    private EmailVerificationRequestService service;
+
+    @MockBean
+    private AuthenticationService authService;
+
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter(
+                        "UTF-8", true))
+                .defaultRequest(
+                        post("/verification/email")
+                                .header(HttpHeaders.AUTHORIZATION,
+                                        "Bearer " + ACCESS_TOKEN))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+    }
+
+    @DisplayName("이메일 인증 요청이 성공적으로 이루어지면 202 accepted를 반환한다.")
+    @Test
+    void POST_request_email_verification() throws Exception {
+        given(service.requestEmailVerification(anyLong()))
+                .willReturn(EmailToken.createEmailToken(1L));
+        mockMvc.perform(
+                post("/verification/email"))
+                .andExpect(
+                status().isAccepted());
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/EmailVerificationRequestServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/EmailVerificationRequestServiceTest.java
@@ -1,0 +1,43 @@
+package com.codesoom.myseat.services.verification.email;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.codesoom.myseat.repositories.EmailTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationRequestServiceTest {
+
+    @InjectMocks
+    private EmailVerificationRequestService service;
+
+    @Mock
+    private EmailTokenRepository repository;
+
+    @DisplayName("주어진 유저 id로 생성된 토큰은 유효하다.")
+    @Test
+    void requestEmailVerificationTest() {
+        //given
+        Long userId = 1L;
+        given(repository.save(any()))
+                .willReturn(EmailToken.createEmailToken(userId));
+
+        //when
+        EmailToken token = service.requestEmailVerification(userId);
+
+        //then
+        assertThat(token.isExpired()).isFalse();
+        assertThat(token.getExpirationDate()).isAfter(LocalDateTime.now());
+    }
+
+}


### PR DESCRIPTION
앞으로 계획이나 회고작성 알림 메일을 발송하기 위해 이메일 인증이 필요합니다.
따라서 이메일 인증 기능이 추가되어야 합니다.

사용자가 이메일 인증 요청을 하면, 해당 api로 요청을 받게됩니다.
그리고 성공적으로 토큰이 생성되면 사용자에게 이메일 인증 링크가 담긴 메일을 발송할 예정입니다.