### PR TITLE
이메일 인증에 필요한 중요 정보들을 숨겨라

### DIFF
--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -25,3 +25,5 @@ ehthumbs_vista.db
 *.log
 *.jar
 *.war
+
+secret.yml


### PR DESCRIPTION
이메일 인증에 필요한 API key와 발신인 메일 주소를 담고 있는 secret.yml을 gitignore에 추가했습니다.