### PR TITLE
계획과 회고작성여부를 확인할수있는 예약내역을 볼수있게하라 

### DIFF
--- a/app-admin/src/Containers/ReservationsContainer/index.tsx
+++ b/app-admin/src/Containers/ReservationsContainer/index.tsx
@@ -1,9 +1,33 @@
-import ReservationsList from '../../components/ReservationsList';
+import { useEffect } from 'react';
 
-import { reservations } from '../../fixtures/reservations';
+import { useAppDispatch, useAppSelector } from '../../hooks';
+
+import { loadReservations, savePage } from '../../redux/reservationsSlice';
+
+import ReservationsList from '../../components/ReservationsList';
 
 import columns from '../../data/columns';
 
 export default function ReserVationsContainer() {
-  return <ReservationsList reservations={reservations} columns={columns}/>;
+  const dispatch = useAppDispatch();
+
+  const { pagination, reservations } = useAppSelector((store) => store.reservations);
+
+  const { page } = pagination;
+
+  const handleChangePage = (e: React.ChangeEvent<unknown>, value: number): void => {
+    dispatch(savePage(value));
+  };
+
+  useEffect(() => {
+    dispatch(loadReservations());
+  }, [page]);
+
+  return (
+    <ReservationsList
+      pagination={pagination}
+      reservations={reservations}
+      columns={columns}
+      onChange={handleChangePage} />
+  );
 }

--- a/app-admin/src/components/ReservationsList/index.tsx
+++ b/app-admin/src/components/ReservationsList/index.tsx
@@ -9,6 +9,8 @@ import {
   Table,
   TableBody,
   Button,
+  TableFooter,
+  Pagination,
 } from '@mui/material';
 
 import { Props } from './typings';
@@ -23,7 +25,24 @@ const StyledPaper = styled(Paper)({
   marginTop: '4rem',
 });
 
-export default function ReservationsList({ reservations, columns }: Props) {
+const ContentRow = styled(TableRow)(({ backgroundcolor, color }: { backgroundcolor?: string, color?: string }) => ({
+  backgroundColor: backgroundcolor ?? '#FFFFFF',
+
+  'td, button': {
+    color: color ?? '#000000',
+  },
+}));
+
+export default function ReservationsList({ reservations, columns, pagination, onChange }: Props) {
+  const { totalPages } = pagination;
+
+  const statuses: { [key: string]: { text: string, backgroundColor?: string, color?: string }; } = {
+    'RESERVED': { text: '예약 완료' },
+    'CANCELED': { text: '예약 취소', backgroundColor: '#D5D5D5' },
+    'RETROSPECTIVE_WAITING': { text: '회고작성 전' },
+    'RETROSPECTIVE_COMPLETE': { text: '회고작성 완료', backgroundColor: '#10B5E8', color: '#FFFFFF' },
+  };
+
   return (
     <Wrapper>
       <StyledPaper>
@@ -32,24 +51,52 @@ export default function ReservationsList({ reservations, columns }: Props) {
             <TableHead>
               <TableRow>
                 {columns.map(({ label, id }) => (
-                  <TableCell align="center" key={id}>
+                  <TableCell
+                    key={id}
+                    sx={{ backgroundColor: '#1976d2', color: '#FFFFFF' }}
+                    align="center"
+                  >
                     {label}
                   </TableCell>
                 ))}
               </TableRow>
             </TableHead>
+
             <TableBody>
-              {reservations.map(({ id, date, status, user: { name } }) => (
-                <TableRow key={id}>
-                  <TableCell align="center">{name}</TableCell>
-                  <TableCell align="center">{date}</TableCell>
-                  <TableCell align="center">
-                    <Button>상세보기</Button>
-                  </TableCell>
-                  <TableCell align="center">{status}</TableCell>
-                </TableRow>
-              ))}
+              {reservations.map(({ id, date, status, user: { name } }) => {
+                const { text, backgroundColor, color } = statuses[status];
+
+                const waiting = status === 'RETROSPECTIVE_WAITING';
+                const canceled = status === 'CANCELED';
+
+                return (
+                  <ContentRow
+                    key={id}
+                    backgroundcolor={backgroundColor}
+                    color={color}
+                  >
+                    <TableCell align="center">{name}</TableCell>
+                    <TableCell align="center">{date}</TableCell>
+                    <TableCell align="center">
+                      <Button disabled={canceled} >상세보기</Button>
+                    </TableCell>
+                    <TableCell align="center">
+                      <Button disabled={waiting || canceled}>
+                        {text}
+                      </Button>
+                    </TableCell>
+                  </ContentRow>
+                );
+              })}
             </TableBody>
+
+            <TableFooter>
+              <TableRow>
+                <TableCell align="center">
+                  <Pagination count={totalPages} onChange={onChange} color="primary" />
+                </TableCell>
+              </TableRow>
+            </TableFooter>
           </Table>
         </TableContainer>
       </StyledPaper>

--- a/app-admin/src/components/ReservationsList/typings.ts
+++ b/app-admin/src/components/ReservationsList/typings.ts
@@ -1,22 +1,30 @@
 interface User {
-  id: number,
-  name: string
+  id: number;
+  name: string;
 }
 
-interface Reservation {
-  id: number,
-  date: string,
-  content: string,
-  status: string,
-  user: User
+export interface Reservation {
+  id: number;
+  date: string;
+  content: string;
+  status: string;
+  user: User;
 }
 
 interface Column {
-  id: number,
-  label: string,
+  id: number;
+  label: string;
+}
+
+export interface Pagination {
+  page: number;
+  size: number;
+  totalPages: number;
 }
 
 export interface Props {
-  reservations: Reservation[],
-  columns: Column[]
+  reservations: Reservation[];
+  columns: Column[];
+  pagination: Pagination;
+  onChange: (e: React.ChangeEvent<unknown>, value: number)=> void;
 }

--- a/app-admin/src/fixtures/reservations.ts
+++ b/app-admin/src/fixtures/reservations.ts
@@ -2,7 +2,7 @@ export const reservations = [{
   id: 1,
   date: '2022-10-25',
   content: '알고리즘 풀기',
-  status: 'RETROSPECTIVE_WATING',
+  status: 'RETROSPECTIVE_WAITING',
   user: {
     id: 1,
     name: '홍길동',
@@ -20,7 +20,7 @@ export const reservations = [{
   id: 3,
   date: '2022-10-27',
   content: '리액트 공부',
-  status: 'RETROSPECTIVE_WATING',
+  status: 'RETROSPECTIVE_WAITING',
   user: {
     id: 3,
     name: '김현지',

--- a/app-admin/src/main.tsx
+++ b/app-admin/src/main.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
+
 import ReactDOM from 'react-dom/client';
 
 import { BrowserRouter } from 'react-router-dom';
+
+import { Provider } from 'react-redux';
+
+import { store } from './store';
 
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
 );

--- a/app-admin/src/redux/reservationsSlice.ts
+++ b/app-admin/src/redux/reservationsSlice.ts
@@ -1,0 +1,66 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { AppDispatch, RootState } from './../store';
+
+import { getReservations } from '../service/reservations';
+
+import { Pagination, Reservation } from '../components/ReservationsList/typings';
+
+interface ReservationsState {
+  pagination: Pagination;
+  reservations: Reservation[];
+}
+
+export const initialState: ReservationsState = {
+  pagination: {
+    page: 1,
+    size: 10,
+    totalPages: 1,
+  },
+  reservations: [],
+};
+
+const { actions, reducer } = createSlice({
+  name: 'reservations',
+  initialState,
+  reducers: {
+    savePagination: (state, { payload }) => ({
+      ...state,
+      pagination: payload,
+    }),
+    savePage: (state, { payload }) => ({
+      ...state,
+      pagination: {
+        ...state.pagination,
+        page: payload,
+      },
+    }),
+    saveReservations: (state, { payload }) => ({
+      ...state,
+      reservations: payload,
+    }),
+  },
+});
+
+export const {
+  savePagination,
+  savePage,
+  saveReservations,
+} = actions;
+
+export function loadReservations() {
+  return async (dispatch: AppDispatch, getState: ()=> RootState) => {
+    const { reservations: { pagination: { page, size } } } = getState();
+
+    try {
+      const { pagination, reservations } = await getReservations({ page, size });
+
+      dispatch(savePagination(pagination));
+      dispatch(saveReservations(reservations));
+    } catch (error) {
+      alert('정보가 없습니다');
+    }
+  };
+}
+
+export default reducer;

--- a/app-admin/src/service/api.ts
+++ b/app-admin/src/service/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const BASE_URL = 'https://api.codesoom-myseat.site/';
+
+export const httpClient = axios.create({
+  baseURL: BASE_URL,
+});

--- a/app-admin/src/service/reservations.ts
+++ b/app-admin/src/service/reservations.ts
@@ -1,0 +1,13 @@
+import { httpClient } from './api';
+
+export const getReservations = async ({ page, size }: { page: number; size: number }) => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  const { data } = await httpClient.get(`/admin/reservations?page=${page}&size=${size}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return data;
+};
+
+export const x = () => {};

--- a/app-admin/src/store.ts
+++ b/app-admin/src/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import reservationsReudcer from './redux/reservationsSlice';
+
 export const store = configureStore({
   reducer: {
+    reservations: reservationsReudcer,
   },
-
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
공부방의 규칙은 계획과 회고를 작성해야하는것입니다.
관리자는 회원들의 규칙과 계획을 작성했는지 확인할수있는 예약내역페이지가 필요합니다.
예약내역 페이지를 만들어 예약자 , 날짜 , 규칙 , 계획 을 확인할수있는 예약내역페이지를 만들었습니다

예약내역에서 회고를 작성한사람은 파란색 바탕 으로 표시될수있게했습니다.
예약내역에서 예약취소를 한사람은 회색 바탕 으로 표시될수있게했습니다.
페이지네이션을 구현하여 페이징이 가능하도록 했습니다.

### api 연결 화면
![Oct-28-2022 12-13-11](https://user-images.githubusercontent.com/57708817/198493182-ccef760f-8168-4d18-a449-2ba5b2b86e31.gif)

