### PR TITLE
이메일 인증 토큰을 검증하는 API를 만들어라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .frameOptions().sameOrigin()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/", "/docs/**", "/signup", "/login", "/seats").permitAll()
+                .antMatchers("/", "/docs/**", "/signup", "/login",
+                        "/seats", "/verification/email/verify").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilter(authenticationFilter())

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/ControllerErrorAdvice.java
@@ -86,4 +86,10 @@ public class ControllerErrorAdvice {
         return e.getMessage();
     }
 
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(EmailTokenException.class)
+    public String handleEmailTokenException(EmailTokenException e) {
+        return e.getMessage();
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenController.java
@@ -1,0 +1,31 @@
+package com.codesoom.myseat.controllers.verification.email.verify;
+
+import com.codesoom.myseat.dto.VerifyEmailTokenRequest;
+import com.codesoom.myseat.services.verification.email.verify.VerifyEmailTokenService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@CrossOrigin
+@RequestMapping("/verification/email/verify")
+@RestController
+public class VerifyEmailTokenController {
+
+    private final VerifyEmailTokenService service;
+
+    public VerifyEmailTokenController(final VerifyEmailTokenService service) {
+        this.service = service;
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping
+    public void verifyEmailToken(
+            @RequestBody VerifyEmailTokenRequest request) {
+        service.verifyEmailToken(request);
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/EmailToken.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/EmailToken.java
@@ -32,6 +32,16 @@ public class EmailToken {
 
     private Long userId;
 
+    public EmailToken(final String id,
+                      final LocalDateTime expirationDate,
+                      final boolean expired,
+                      final Long userId) {
+        this.id = id;
+        this.expirationDate = expirationDate;
+        this.expired = expired;
+        this.userId = userId;
+    }
+
     /**
      * 주어진 회원 id에 대해 생성된 이메일 인증 토큰을 반환합니다.
      *
@@ -53,6 +63,16 @@ public class EmailToken {
      */
     public void setTokenExpired() {
         this.expired = true;
+    }
+
+    /**
+     * 토큰의 만료 여부를 확인합니다.
+     *
+     * @return 토큰 만료 일시가 현재보다 이전이라면 true, 아니라면 false
+     */
+    public boolean isExpired() {
+        return this.expirationDate
+                .isBefore(LocalDateTime.now());
     }
 
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -66,4 +66,12 @@ public class User {
         return passwordEncoder.matches(password, this.password);
     }
 
+    /** 이메일 인증이 완료된 유저에게 새로운 role을 추가합니다.*/
+    public void verifyEmail() {
+        this.roles.add(Role.builder()
+                .userId(this.id)
+                .roleName("VERIFIED_USER")
+                .build());
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/VerifyEmailTokenRequest.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/VerifyEmailTokenRequest.java
@@ -1,0 +1,18 @@
+package com.codesoom.myseat.dto;
+
+import lombok.Getter;
+
+/** 이메일 인증 토큰 정보 */
+@Getter
+public class VerifyEmailTokenRequest {
+
+    private String token;
+
+    public VerifyEmailTokenRequest() {
+    }
+
+    public VerifyEmailTokenRequest(final String token) {
+        this.token = token;
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/exceptions/EmailTokenException.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/exceptions/EmailTokenException.java
@@ -1,0 +1,13 @@
+package com.codesoom.myseat.exceptions;
+
+public class EmailTokenException
+        extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE
+            = "올바르지 않은 요청입니다.";
+
+    public EmailTokenException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenService.java
@@ -1,0 +1,47 @@
+package com.codesoom.myseat.services.verification.email.verify;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.VerifyEmailTokenRequest;
+import com.codesoom.myseat.exceptions.EmailTokenException;
+import com.codesoom.myseat.exceptions.UserNotFoundException;
+import com.codesoom.myseat.repositories.EmailTokenRepository;
+import com.codesoom.myseat.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/** 인증 토큰 검증 서비스 */
+@Service
+public class VerifyEmailTokenService {
+
+    private final EmailTokenRepository repository;
+    private final UserRepository userRepository;
+
+    public VerifyEmailTokenService(
+            final EmailTokenRepository repository,
+            final UserRepository userRepository) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 주어진 이메일 인증용 토큰을 찾을 수 있고, 만료되지 않으면 인증된 유저로 갱신합니다.
+     *
+     * @param request 인증 토큰
+     * @throws EmailTokenException 주어진 토큰으로 찾을 수 없거나 만료된 경우 던짐
+     * @throws UserNotFoundException 토큰에 해당하는 유저 id로 유저를 찾을 수 없는 경우 던짐
+     */
+    @Transactional
+    public void verifyEmailToken(VerifyEmailTokenRequest request) {
+        EmailToken token = repository.findById(request.getToken())
+                .orElseThrow(EmailTokenException::new);
+        if (token.isExpired()) {
+            throw new EmailTokenException();
+        }
+        User user = userRepository.findById(token.getUserId())
+                .orElseThrow(UserNotFoundException::new);
+        user.verifyEmail();
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenControllerTest.java
@@ -80,7 +80,7 @@ class VerifyEmailTokenControllerTest {
 
     @DisplayName("이메일 인증 토큰이 올바르지 않으면 404 not found를 반환한다.")
     @Test
-    void POST_verify_email_not_found() throws Exception {
+    void POST_verify_email_with_invalid_token_returns_not_found() throws Exception {
         VerifyEmailTokenRequest request
                 = new VerifyEmailTokenRequest("lfkd8122lMSD32k");
         doThrow(EmailTokenException.class)

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/verification/email/verify/VerifyEmailTokenControllerTest.java
@@ -1,0 +1,112 @@
+package com.codesoom.myseat.controllers.verification.email.verify;
+
+import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.dto.VerifyEmailTokenRequest;
+import com.codesoom.myseat.exceptions.EmailTokenException;
+import com.codesoom.myseat.exceptions.UserNotFoundException;
+import com.codesoom.myseat.services.auth.AuthenticationService;
+import com.codesoom.myseat.services.verification.email.verify.VerifyEmailTokenService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(VerifyEmailTokenController.class)
+class VerifyEmailTokenControllerTest {
+
+    private static final String ACCESS_TOKEN
+            = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
+
+    @MockBean
+    private VerifyEmailTokenService service;
+
+    @MockBean
+    private AuthenticationService authService;
+
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilters(new CharacterEncodingFilter(
+                        "UTF-8", true))
+                .apply(springSecurity())
+                .alwaysDo(print())
+                .build();
+    }
+
+    @DisplayName("이메일 인증 토큰으로 인증에 성공하면 204 no content를 반환한다.")
+    @Test
+    void POST_verify_email() throws Exception {
+        VerifyEmailTokenRequest request
+                = new VerifyEmailTokenRequest("lfkd8122lMSD32k");
+
+        mockMvc.perform(post("/verification/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("이메일 인증 토큰이 올바르지 않으면 404 not found를 반환한다.")
+    @Test
+    void POST_verify_email_not_found() throws Exception {
+        VerifyEmailTokenRequest request
+                = new VerifyEmailTokenRequest("lfkd8122lMSD32k");
+        doThrow(EmailTokenException.class)
+                .when(service)
+                .verifyEmailToken(any());
+
+        mockMvc.perform(post("/verification/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @DisplayName("이메일 인증 토큰에 대한 유저 정보를 찾을 수 없으면 " +
+            "404 not found를 반환한다.")
+    @Test
+    void POST_verify_email_with_user_not_found() throws Exception {
+        VerifyEmailTokenRequest request
+                = new VerifyEmailTokenRequest("lfkd8122lMSD32k");
+        doThrow(UserNotFoundException.class)
+                .when(service)
+                .verifyEmailToken(any());
+
+        mockMvc.perform(post("/verification/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+}

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenServiceTest.java
@@ -66,7 +66,7 @@ class VerifyEmailTokenServiceTest {
 
     @DisplayName("토큰을 찾을 수 없으면 EmailTokenException을 던진다.")
     @Test
-    void throw_when_not_found_token() {
+    void throw_when_token_not_found() {
         given(repository.findById(anyString()))
                 .willReturn(Optional.empty());
 

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/verification/email/verify/VerifyEmailTokenServiceTest.java
@@ -1,0 +1,110 @@
+package com.codesoom.myseat.services.verification.email.verify;
+
+import com.codesoom.myseat.domain.EmailToken;
+import com.codesoom.myseat.domain.Role;
+import com.codesoom.myseat.domain.User;
+import com.codesoom.myseat.dto.VerifyEmailTokenRequest;
+import com.codesoom.myseat.exceptions.EmailTokenException;
+import com.codesoom.myseat.exceptions.UserNotFoundException;
+import com.codesoom.myseat.repositories.EmailTokenRepository;
+import com.codesoom.myseat.repositories.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VerifyEmailTokenServiceTest {
+
+    @InjectMocks
+    private VerifyEmailTokenService service;
+
+    @Mock
+    private EmailTokenRepository repository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @DisplayName("유효한 토큰이 주어지면 유저의 Role에 VERIFIED_USER가 추가된다.")
+    @Test
+    void verifyEmailToken() {
+        //given
+        User mockUser = User.builder()
+                .id(1L)
+                .name("김철수")
+                .email("soo@email.com")
+                .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .build();
+        given(repository.findById(anyString()))
+                .willReturn(Optional.of(
+                        EmailToken.createEmailToken(1L)));
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.ofNullable(mockUser));
+
+        //when
+        service.verifyEmailToken(new VerifyEmailTokenRequest("dslkfajsidfwl"));
+
+        //then
+        assertThat(mockUser.getRoles()
+                .stream()
+                .map(Role::getRoleName)
+                .collect(Collectors.toList()))
+                .contains("VERIFIED_USER");
+    }
+
+    @DisplayName("토큰을 찾을 수 없으면 EmailTokenException을 던진다.")
+    @Test
+    void throw_when_not_found_token() {
+        given(repository.findById(anyString()))
+                .willReturn(Optional.empty());
+
+        assertThrows(EmailTokenException.class,
+                () -> service.verifyEmailToken(
+                        new VerifyEmailTokenRequest("dslkfajsidfwl")));
+    }
+
+    @DisplayName("토큰이 만료되었으면 EmailTokenException을 던진다.")
+    @Test
+    void throw_when_token_expired() {
+        given(repository.findById(anyString()))
+                .willReturn(
+                        Optional.of(new EmailToken(
+                                "dslkfajsidfwl",
+                                LocalDateTime.now().minusMinutes(30L),
+                                true,
+                                1L))
+                );
+
+        assertThrows(EmailTokenException.class,
+                () -> service.verifyEmailToken(
+                        new VerifyEmailTokenRequest("dslkfajsidfwl")));
+    }
+
+    @DisplayName("토큰과 일치하는 userId로 유저를 찾을 수 없으면"
+            + "UserNotFoundException을 던진다.")
+    @Test
+    void throw_when_user_not_found() {
+        given(repository.findById(anyString()))
+                .willReturn(Optional.of(
+                        EmailToken.createEmailToken(1L)));
+        given(userRepository.findById(anyLong()))
+                .willReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class,
+                () -> service.verifyEmailToken(
+                        new VerifyEmailTokenRequest("dslkfajsidfwl")));
+    }
+
+}


### PR DESCRIPTION
사용자가 이메일 인증 메일을 수신한 뒤, 인증 링크를 클릭해 프론트를 거쳐 서버로 토큰이 도착합니다.
받은 토큰이 유효한지 검증하는 API를 만들었습니다.