### PR TITLE
일단 빌드에 성공하도록 민감 정보를 임의의 값으로 대체하라

### DIFF
--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -25,5 +25,3 @@ ehthumbs_vista.db
 *.log
 *.jar
 *.war
-
-secret.yml

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -25,3 +25,5 @@ ehthumbs_vista.db
 *.log
 *.jar
 *.war
+
+application.yml

--- a/app-server/app/src/main/java/com/codesoom/myseat/helpers/EmailHelper.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/helpers/EmailHelper.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 @Component
 public class EmailHelper {
 
-    @Value("${email.api-key}")
+    @Value("${email.auth.key}")
     private static String API_KEY;
 
     @Value("${email.from}")

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -15,6 +15,8 @@ jwt:
   secret: "12345678901234567890123456789012"
 
 email:
+  from: "codesoom@gmail.com"
   auth:
+    key: "abc"
     subject: "코드숨 공부방 이메일 인증 안내입니다."
     url: "https://space.codesoom.com/verification/email?token="


### PR DESCRIPTION
기존에는 민감 정보들을 담고 있는 secret.yml이 없어서 이메일 인증을 테스트 하려면 secret.yml을 직접 넣어줘야 했습니다.
따라서 민감 정보를 기존의 application.yml에 포함시키되 임의의 값으로 대체했고,
로컬 테스트 시에는 임의의 값을 실제 key값으로 바꿔주기만 하면 되도록 수정했습니다.