### PR TITLE
관리자 예약자 회고 작성 시간 확인하는 속성 추가하라.

### DIFF
--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -25,5 +25,3 @@ ehthumbs_vista.db
 *.log
 *.jar
 *.war
-
-secret.yml

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -25,3 +25,5 @@ ehthumbs_vista.db
 *.log
 *.jar
 *.war
+
+application.yml

--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailController.java
@@ -1,7 +1,7 @@
 package com.codesoom.myseat.controllers.admin.reservations.retrospective;
 
 import com.codesoom.myseat.domain.Retrospective;
-import com.codesoom.myseat.dto.RetrospectiveResponse;
+import com.codesoom.myseat.dto.AdminRetrospectiveResponse;
 import com.codesoom.myseat.services.reservations.retrospectives.RetrospectiveDetailService;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -30,14 +30,15 @@ public class AdminRetrospectiveDetailController {
      */
     @PreAuthorize("isAuthenticated() and hasAuthority('ADMIN')")
     @RequestMapping("/{id}/retrospectives")
-    public RetrospectiveResponse retrospectives(
+    public AdminRetrospectiveResponse retrospectives(
             @PathVariable(name = "id") final Long id
     ) {
         Retrospective retrospective = service.retrospective(id);
 
-        return RetrospectiveResponse.builder()
+        return AdminRetrospectiveResponse.builder()
                 .id(retrospective.getId())
                 .content(retrospective.getContent())
+                .createdDate(retrospective.getCreatedDate())
                 .build();
     }
 

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminRetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminRetrospectiveResponse.java
@@ -17,6 +17,7 @@ public class AdminRetrospectiveResponse {
 
     private String content;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdDate;
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminRetrospectiveResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/AdminRetrospectiveResponse.java
@@ -1,0 +1,22 @@
+package com.codesoom.myseat.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/** 관리자 회고 상세 조회 응답 정보 */
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminRetrospectiveResponse {
+
+    private Long id;
+
+    private String content;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdDate;
+}

--- a/app-server/app/src/main/java/com/codesoom/myseat/helpers/EmailHelper.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/helpers/EmailHelper.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 @Component
 public class EmailHelper {
 
-    @Value("${email.api-key}")
+    @Value("${email.auth.key}")
     private static String API_KEY;
 
     @Value("${email.from}")

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -15,6 +15,8 @@ jwt:
   secret: "12345678901234567890123456789012"
 
 email:
+  from: "codesoom@gmail.com"
   auth:
+    key: "abc"
     subject: "코드숨 공부방 이메일 인증 안내입니다."
     url: "https://space.codesoom.com/verification/email?token="

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailControllerTest.java
@@ -87,7 +87,9 @@ class AdminRetrospectiveDetailControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         containsString(
-                                "{\"id\":1,\"content\":\"잘했다.\",\"createdDate\":\"2022-10-26T17:22:00\"}"))
+                                "{\"id\":1,\"content\":\"잘했다.\",\"" +
+                                        "createdDate\":\"2022-10-26T17:22:00\"}")
+                    )
                 );
 
     }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/admin/reservations/retrospective/AdminRetrospectiveDetailControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
@@ -68,6 +69,7 @@ class AdminRetrospectiveDetailControllerTest {
     @Test
     void GET_reservation_responses_retrospective() throws Exception {
         Long reservationId = 1L;
+        LocalDateTime NOW = LocalDateTime.of(2022, 10, 26, 17, 22, 0);
 
         given(authService.roles(any())).willReturn(List.of(ADMIN_ROLE));
 
@@ -75,6 +77,7 @@ class AdminRetrospectiveDetailControllerTest {
                 .willReturn(Retrospective.builder()
                         .id(reservationId)
                         .content("잘했다.")
+                        .createdDate(NOW)
                         .build());
 
         ResultActions perform
@@ -84,7 +87,7 @@ class AdminRetrospectiveDetailControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(
                         containsString(
-                                "{\"id\":1,\"content\":\"잘했다.\"}"))
+                                "{\"id\":1,\"content\":\"잘했다.\",\"createdDate\":\"2022-10-26T17:22:00\"}"))
                 );
 
     }


### PR DESCRIPTION
관리자가 회고 작성 시간을 확인 하기 위해서 작업을 진행했습니다. 
기존에 RetrospectiveResponse에 `LocalDateTime createdDate` 추가 된`AdminRetrospectiveResponse` 객체를 생성을 했습니다.
LocalDateTime에 `@JsonFormat`을 추가한 이유는 JSON 형태로 출력 할 때 날짜 형식을 변경 하기위해서 사용했습니다.

`2022-10-28T14:47:30` 중간에 'T'가 들어 간 이유는 중간에 띄어 쓰기가 있으면 잘못된 데이터가 들어가는 것을 방지하기위해서 T를 추가했습니다.

**참고**
[jsonformat](https://www.baeldung.com/jackson-jsonformat)
[SpringBoot에서 날짜 타입 JSON 변환에 대한 오해 풀기](https://jojoldu.tistory.com/361)
