### PR TITLE
마이페이지 응답 데이터에 이메일 인증여부 속성을 추가하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/mypage/MyPageController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/mypage/MyPageController.java
@@ -15,14 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 마이페이지 컨트롤러
- */
+/** 마이페이지 컨트롤러 */
 @RestController
 @RequestMapping("/mypage")
 @CrossOrigin
 @Slf4j
 public class MyPageController {
+
     private final UserService userService;
 
     public MyPageController(
@@ -55,6 +54,7 @@ public class MyPageController {
         return MyPageResponse.builder()
                 .name(user.getName())
                 .email(user.getEmail())
+                .emailVerified(user.isEmailVerified())
                 .build();
     }
     

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -12,6 +12,7 @@ import javax.persistence.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -72,6 +73,14 @@ public class User {
                 .userId(this.id)
                 .roleName("VERIFIED_USER")
                 .build());
+    }
+
+    /** 이메일 인증된 회원이면 true, 아니라면 false를 반환합니다. */
+    public boolean isEmailVerified() {
+        return this.roles.stream()
+                .map(Role::getRoleName)
+                .collect(Collectors.toList())
+                .contains("VERIFIED_USER");
     }
 
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/dto/MyPageResponse.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/dto/MyPageResponse.java
@@ -14,4 +14,6 @@ public class MyPageResponse {
     String name;
     
     String email;
+
+    boolean emailVerified;
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/controllers/mypage/MyPageControllerTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/controllers/mypage/MyPageControllerTest.java
@@ -1,5 +1,6 @@
 package com.codesoom.myseat.controllers.mypage;
 
+import com.codesoom.myseat.domain.Role;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.services.auth.AuthenticationService;
 import com.codesoom.myseat.services.users.UserService;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -42,6 +45,9 @@ class MyPageControllerTest {
                 .name("김철수")
                 .email("soo@email.com")
                 .password("$2a$10$hxqWrlGa7SQcCEGURjmuQup4J9kN6qnfr4n7j7R3LvzHEoEOUTWeW")
+                .roles(List.of(
+                        new Role(1L, 1L, "USER"),
+                        new Role(2L, 1L, "VERIFIED_USER")))
                 .build();
 
         given(authService.parseToken(ACCESS_TOKEN))
@@ -55,7 +61,8 @@ class MyPageControllerTest {
 
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("김철수"))
-                .andExpect(jsonPath("$.email").value("soo@email.com"));
+                .andExpect(jsonPath("$.email").value("soo@email.com"))
+                .andExpect(jsonPath("$.emailVerified").value(true));
     }
 
 }


### PR DESCRIPTION
`emailVerified`라는 이름으로 이메일 인증여부를 불리언 값으로 응답합니다.