### PR TITLE
연관관계 매핑 cascade옵션을 CascadeType.ALL로 설정하라

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/User.java
@@ -36,7 +36,7 @@ public class User {
     private String password;
 
     @Builder.Default
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "userId")
     private List<Role> roles = new ArrayList<>();
 


### PR DESCRIPTION
이메일 인증 메일을 받은 후, 서버로 전달받은 이메일 인증 토큰이 유효하다면 유저의 `Role`에 `VERIFIED_USER`를 추가해주고 있습니다.
테스트 중 `object references an unsaved transient instance - save the transient instance before flushing`오류가 났고,
이 오류를 해결하기 위해 `cascade` 옵션을 설정해주었습니다.

기존에는 연관관계 매핑 시 `cascade`옵션을 따로 설정해주지 않았습니다.
`cascade`옵션은 영속성 전이 기능을 사용할 때 사용하는 옵션입니다.
현재 설정한 `CascadeType.ALL` 옵션은 모든 CascadeType을 설정하는 것입니다.
부모 엔티티를 저장하면 자식 엔티티도 함께 저장되고, 부모 엔티티가 삭제될 경우 자식 엔티티도 삭제됩니다.

이메일 인증이 완료되면 `Role`에 `VERIFIED_USER`를 추가하고, 이 값이 추가되면 자동으로 자식 엔티티가 저장됩니다.


