### PR TITLE
SendGrid 설정 정보를 ConfigurationProperties를 통해 객체로 관리하라

### DIFF
--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -27,3 +27,4 @@ ehthumbs_vista.db
 *.war
 
 secret.yml
+application-secret.yml

--- a/app-server/app/src/main/java/com/codesoom/myseat/App.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/App.java
@@ -1,11 +1,14 @@
 package com.codesoom.myseat;
 
+import com.codesoom.myseat.properties.SendGridProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableConfigurationProperties({SendGridProperties.class})
 @SpringBootApplication
 @EnableScheduling
 public class App {

--- a/app-server/app/src/main/java/com/codesoom/myseat/properties/SendGridProperties.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/properties/SendGridProperties.java
@@ -1,0 +1,26 @@
+package com.codesoom.myseat.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "send-grid")
+public class SendGridProperties {
+
+    private String apiKey;
+    private String from;
+
+    public SendGridProperties(final String apiKey, final String from) {
+        this.apiKey = apiKey;
+        this.from = from;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+}

--- a/app-server/app/src/main/resources/application.yml
+++ b/app-server/app/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+  profiles.include: secret
   datasource:
     url: ${url:jdbc:mariadb://localhost:3306/myseattest}
     username: root
@@ -14,7 +15,4 @@ spring:
 jwt:
   secret: "12345678901234567890123456789012"
 
-email:
-  auth:
-    subject: "코드숨 공부방 이메일 인증 안내입니다."
-    url: "https://space.codesoom.com/verification/email?token="
+email.auth.url: "https://space.codesoom.com/verification/email?token="


### PR DESCRIPTION
ConfigurationProperties를 사용해 설정정보를 객체로 사용할 수 있습니다. 
현재 스프링버전에서는 특정 설정 파일을 포함하려면 `applicaion-`으로 시작하는 파일명을 가져야 합니다.

따라서 `application-secret.yml`파일에 SendGrid 설정정보를 담고, 해당 파일을 `.gitignore`에 등록했습니다.