### PR TITLE
Retrospective 회고 저장 API를 리팩토링을 하라.

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
@@ -34,7 +34,10 @@ public class RetrospectiveAddController {
     private final UserService userService;
     private final ReservationAddService reservationAddService;
 
-    public RetrospectiveAddController(RetrospectiveAddService retrospectiveAddService, UserService userService, ReservationAddService reservationAddService) {
+    public RetrospectiveAddController(
+            RetrospectiveAddService retrospectiveAddService,
+            UserService userService,
+            ReservationAddService reservationAddService) {
         this.retrospectiveAddService = retrospectiveAddService;
         this.userService = userService;
         this.reservationAddService = reservationAddService;
@@ -71,7 +74,7 @@ public class RetrospectiveAddController {
             throw new ContentTooShortException();
         }
 
-        retrospectiveAddService.createRetrospective(user, id, content);
+        retrospectiveAddService.create(user, id, content);
     }
 
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -119,4 +119,19 @@ public class Reservation {
         return this.status == ReservationStatus.CANCELED;
     }
 
+    /**
+     * 회고를 등록합니다.
+     *
+     * @param reservation 예약 정보
+     * @param content 회고 내용
+     * @return 회고 내용 등록
+     */
+    public Retrospective addRetrospective(final Reservation reservation,
+                                          final String content) {
+        return Retrospective.builder()
+                .reservation(reservation)
+                .content(content)
+                .build();
+    }
+
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddService.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddService.java
@@ -5,7 +5,6 @@ import com.codesoom.myseat.domain.Retrospective;
 import com.codesoom.myseat.domain.User;
 import com.codesoom.myseat.exceptions.ContentTooLongException;
 import com.codesoom.myseat.exceptions.NotOwnedReservationException;
-import com.codesoom.myseat.exceptions.ReservationNotFoundException;
 import com.codesoom.myseat.repositories.ReservationRepository;
 import com.codesoom.myseat.repositories.RetrospectiveRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -36,44 +35,29 @@ public class RetrospectiveAddService {
      * @throws NotOwnedReservationException 예약자가 아닌 회원이 해당 예약에 대해 회고를 작성하려고 한다면 예외를 던집니다.
      * @throws ContentTooLongException 회고의 길이가 너무 길면 던집니다.
      */
-    public Retrospective createRetrospective(final User user,
-                                             final Long reservationId,
-                                             final String content) {
-        if (!isReservedUser(reservationId, user.getId())) {
-            throw new NotOwnedReservationException();
-        }
+    public Retrospective create(final User user,
+                                final Long reservationId,
+                                final String content) {
         log.info("회고 요청: " + content);
 
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(ReservationNotFoundException::new);
+        Reservation reservation = reservationRepository
+                .findByIdAndUser_Id(reservationId, user.getId())
+                .orElseThrow(NotOwnedReservationException::new);
 
         reservation.completeRetrospective();
 
-        Retrospective retrospective = Retrospective.builder()
-                .reservation(reservation)
-                .content(content)
-                .build();
+        Retrospective retrospective = reservation
+                .addRetrospective(reservation, content);
 
         log.info("회고 요청: " + retrospective.getContent());
 
         try {
-            return retrospectiveRepository.save(retrospective);
+            return retrospectiveRepository
+                    .save(retrospective);
         } catch (InvalidDataAccessResourceUsageException e) {
             e.printStackTrace();
             throw new ContentTooLongException();
         }
-    }
-
-    /**
-     * 예약한 회원이면 true, 그렇지 않으면 false를 반환합니다.
-     *
-     * @param reservationId 예약 id
-     * @param userId 회원 id
-     * @return 예약한 회원이면 true, 그렇지 않으면 false
-     */
-    public boolean isReservedUser(final Long reservationId,
-                                  final Long userId) {
-        return reservationRepository.existsByIdAndUser_Id(reservationId, userId);
     }
 
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddServiceTest.java
@@ -70,13 +70,14 @@ class RetrospectiveAddServiceTest {
 
         given(reservationRepository.findById(1L))
                 .willReturn(Optional.of(mockReservation));
-        given(reservationRepository.existsByIdAndUser_Id(1L, mockUser.getId()))
-                .willReturn(true);
         given(retrospectiveRepository.save(any()))
                 .willReturn(mockRetrospective);
+        given(reservationRepository.
+                findByIdAndUser_Id(mockReservation.getId(), mockUser.getId()))
+                .willReturn(Optional.of(mockReservation));
 
         Retrospective retrospective =
-                service.createRetrospective(mockUser, 1L, "잘했다.");
+                service.create(mockUser, 1L, "잘했다.");
 
         assertThat(retrospective.getContent()).isEqualTo("잘했다.");
         assertThat(retrospective.getCreatedDate()).isEqualTo(NOW);
@@ -95,7 +96,7 @@ class RetrospectiveAddServiceTest {
         given(reservationRepository.existsByIdAndUser_Id(1000L, mockUser.getId()))
                 .willReturn(false);
 
-        assertThatThrownBy(() -> service.createRetrospective(mockUser, 1000L, "잘했다."))
+        assertThatThrownBy(() -> service.create(mockUser, 1000L, "잘했다."))
                 .isInstanceOf(NotOwnedReservationException.class);
     }
 
@@ -122,13 +123,14 @@ class RetrospectiveAddServiceTest {
 
         given(reservationRepository.findById(1L))
                 .willReturn(Optional.of(mockReservation));
-        given(reservationRepository.existsByIdAndUser_Id(1L, mockUser.getId()))
-                .willReturn(true);
         given(retrospectiveRepository.save(any()))
                 .willReturn(mockRetrospective);
+        given(reservationRepository.
+                findByIdAndUser_Id(mockReservation.getId(), mockUser.getId()))
+                .willReturn(Optional.of(mockReservation));
 
         Retrospective retrospective =
-                service.createRetrospective(mockUser, 1L, "잘했다.");
+                service.create(mockUser, 1L, "잘했다.");
 
         assertThat(retrospective.getReservation().getStatus())
                 .isEqualTo(RETROSPECTIVE_COMPLETE);


### PR DESCRIPTION
기존 코드는 retrospective가 reservation에 retrospective의 reservation과content를 저장을 합니다.

reservation이 retrospective에 회고를 저장한다. 의도에 맞게 리팩토링을 했습니다.