### PR TITLE
Retrospective 회고 저장 API를 리팩토링을 하라.

### DIFF
--- a/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/controllers/reservations/retrospectives/RetrospectiveAddController.java
@@ -34,7 +34,10 @@ public class RetrospectiveAddController {
     private final UserService userService;
     private final ReservationAddService reservationAddService;
 
-    public RetrospectiveAddController(RetrospectiveAddService retrospectiveAddService, UserService userService, ReservationAddService reservationAddService) {
+    public RetrospectiveAddController(
+            RetrospectiveAddService retrospectiveAddService,
+            UserService userService,
+            ReservationAddService reservationAddService) {
         this.retrospectiveAddService = retrospectiveAddService;
         this.userService = userService;
         this.reservationAddService = reservationAddService;
@@ -71,7 +74,7 @@ public class RetrospectiveAddController {
             throw new ContentTooShortException();
         }
 
-        retrospectiveAddService.createRetrospective(user, id, content);
+        retrospectiveAddService.create(user, id, content);
     }
 
 }

--- a/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
+++ b/app-server/app/src/main/java/com/codesoom/myseat/domain/Reservation.java
@@ -119,4 +119,19 @@ public class Reservation {
         return this.status == ReservationStatus.CANCELED;
     }
 
+    /**
+     * 회고를 등록합니다.
+     *
+     * @param reservation 예약 정보
+     * @param content 회고 내용
+     * @return 회고 내용 등록
+     */
+    public Retrospective addRetrospective(final Reservation reservation,
+                                          final String content) {
+        return Retrospective.builder()
+                .reservation(reservation)
+                .content(content)
+                .build();
+    }
+
 }

--- a/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddServiceTest.java
+++ b/app-server/app/src/test/java/com/codesoom/myseat/services/reservations/retrospectives/RetrospectiveAddServiceTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-
 class RetrospectiveAddServiceTest {
 
     private RetrospectiveAddService service;
@@ -70,13 +69,14 @@ class RetrospectiveAddServiceTest {
 
         given(reservationRepository.findById(1L))
                 .willReturn(Optional.of(mockReservation));
-        given(reservationRepository.existsByIdAndUser_Id(1L, mockUser.getId()))
-                .willReturn(true);
         given(retrospectiveRepository.save(any()))
                 .willReturn(mockRetrospective);
+        given(reservationRepository.
+                findByIdAndUser_Id(mockReservation.getId(), mockUser.getId()))
+                .willReturn(Optional.of(mockReservation));
 
         Retrospective retrospective =
-                service.createRetrospective(mockUser, 1L, "잘했다.");
+                service.create(mockUser, 1L, "잘했다.");
 
         assertThat(retrospective.getContent()).isEqualTo("잘했다.");
         assertThat(retrospective.getCreatedDate()).isEqualTo(NOW);
@@ -95,7 +95,7 @@ class RetrospectiveAddServiceTest {
         given(reservationRepository.existsByIdAndUser_Id(1000L, mockUser.getId()))
                 .willReturn(false);
 
-        assertThatThrownBy(() -> service.createRetrospective(mockUser, 1000L, "잘했다."))
+        assertThatThrownBy(() -> service.create(mockUser, 1000L, "잘했다."))
                 .isInstanceOf(NotOwnedReservationException.class);
     }
 
@@ -122,13 +122,14 @@ class RetrospectiveAddServiceTest {
 
         given(reservationRepository.findById(1L))
                 .willReturn(Optional.of(mockReservation));
-        given(reservationRepository.existsByIdAndUser_Id(1L, mockUser.getId()))
-                .willReturn(true);
         given(retrospectiveRepository.save(any()))
                 .willReturn(mockRetrospective);
+        given(reservationRepository.
+                findByIdAndUser_Id(mockReservation.getId(), mockUser.getId()))
+                .willReturn(Optional.of(mockReservation));
 
         Retrospective retrospective =
-                service.createRetrospective(mockUser, 1L, "잘했다.");
+                service.create(mockUser, 1L, "잘했다.");
 
         assertThat(retrospective.getReservation().getStatus())
                 .isEqualTo(RETROSPECTIVE_COMPLETE);


### PR DESCRIPTION
기존 코드는 retrospective가 reservation에 retrospective의 reservation과 content를 저장을 합니다.

**reservation이 retrospective에 회고를 저장한다.** 의도에 맞게 리팩토링을 했습니다.