### PR TITLE
회고 상세보기를 구현하라

### DIFF
--- a/app-admin/src/Containers/ReservationsContainer/index.tsx
+++ b/app-admin/src/Containers/ReservationsContainer/index.tsx
@@ -7,11 +7,14 @@ import { loadReservations, savePage } from '../../redux/reservationsSlice';
 import ReservationsList from '../../components/ReservationsList';
 
 import columns from '../../data/columns';
+import Modal from '../../component/Modal';
+import { toggleRetrospectivesModal } from '../../redux/retrospectivesSlice';
 
 export default function ReserVationsContainer() {
   const dispatch = useAppDispatch();
 
   const { pagination, reservations } = useAppSelector((store) => store.reservations);
+  const { isOpenRetrospectivesModal } = useAppSelector((store) => store.retrospectives);
 
   const { page } = pagination;
 
@@ -23,11 +26,27 @@ export default function ReserVationsContainer() {
     dispatch(loadReservations());
   }, [page]);
 
+  const handleClickOpenModal = () => {
+    console.log('dd');
+    dispatch(toggleRetrospectivesModal());
+  };
+
+  console.log(isOpenRetrospectivesModal);
+
   return (
-    <ReservationsList
-      pagination={pagination}
-      reservations={reservations}
-      columns={columns}
-      onChange={handleChangePage} />
+    <>
+      <ReservationsList
+        pagination={pagination}
+        reservations={reservations}
+        columns={columns}
+        onClick={handleClickOpenModal}
+        onChange={handleChangePage} />
+      <Modal
+        title='test'
+        content='test'
+        open={isOpenRetrospectivesModal}
+        onClick={handleClickOpenModal}
+      />
+    </>
   );
 }

--- a/app-admin/src/Containers/ReservationsContainer/index.tsx
+++ b/app-admin/src/Containers/ReservationsContainer/index.tsx
@@ -7,31 +7,46 @@ import { loadReservations, savePage } from '../../redux/reservationsSlice';
 import ReservationsList from '../../components/ReservationsList';
 
 import columns from '../../data/columns';
+
 import Modal from '../../component/Modal';
-import { toggleRetrospectivesModal } from '../../redux/retrospectivesSlice';
+
+import {
+  loadRetrospectives,
+  toggleRetrospectivesModal,
+} from '../../redux/retrospectivesSlice';
 
 export default function ReserVationsContainer() {
   const dispatch = useAppDispatch();
 
-  const { pagination, reservations } = useAppSelector((store) => store.reservations);
-  const { isOpenRetrospectivesModal } = useAppSelector((store) => store.retrospectives);
+  const {
+    pagination,
+    reservations,
+  } = useAppSelector((store) => store.reservations);
+
+  const {
+    showRetrospectivesModal,
+    content,
+  } = useAppSelector((store) => store.retrospectives);
 
   const { page } = pagination;
 
-  const handleChangePage = (e: React.ChangeEvent<unknown>, value: number): void => {
+  const handleChangePage = (
+    e: React.ChangeEvent<unknown>,
+    value: number): void => {
     dispatch(savePage(value));
+  };
+
+  const handleClickDetailRetrospectives = (id: number) => {
+    dispatch(loadRetrospectives(id));
   };
 
   useEffect(() => {
     dispatch(loadReservations());
   }, [page]);
 
-  const handleClickOpenModal = () => {
-    console.log('dd');
+  const modalHandler = () => {
     dispatch(toggleRetrospectivesModal());
   };
-
-  console.log(isOpenRetrospectivesModal);
 
   return (
     <>
@@ -39,13 +54,15 @@ export default function ReserVationsContainer() {
         pagination={pagination}
         reservations={reservations}
         columns={columns}
-        onClick={handleClickOpenModal}
-        onChange={handleChangePage} />
+        open={showRetrospectivesModal}
+        onClick={handleClickDetailRetrospectives}
+        onChange={handleChangePage}
+      />
       <Modal
-        title='test'
-        content='test'
-        open={isOpenRetrospectivesModal}
-        onClick={handleClickOpenModal}
+        title='회고 내용'
+        content={content}
+        open={showRetrospectivesModal}
+        onClick={modalHandler}
       />
     </>
   );

--- a/app-admin/src/component/Modal.test.tsx
+++ b/app-admin/src/component/Modal.test.tsx
@@ -16,7 +16,6 @@ describe('modal', () => {
       open={true}
       title="제목"
       content='내용입니다'
-      onClose={onClose}
       onClick={onClick}
     />,
   );

--- a/app-admin/src/component/Modal.tsx
+++ b/app-admin/src/component/Modal.tsx
@@ -15,7 +15,6 @@ interface Props {
   content: string;
   text?: string;
 
-  onClose: React.ReactEventHandler;
   onClick: React.ReactEventHandler;
 }
 
@@ -24,13 +23,12 @@ export default function Modal({
   title,
   content,
   text = '확인',
-  onClose,
   onClick,
 }: Props) {
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClick={onClick}
     >
       <DialogTitle data-testid="title" >
         {title}

--- a/app-admin/src/component/Modal.tsx
+++ b/app-admin/src/component/Modal.tsx
@@ -10,11 +10,9 @@ const DialogContentStyle = { maxHeight: '20rem', whiteSpace: 'pre-line' };
 
 interface Props {
   open: boolean;
-
-  title?: string;
+  title: string;
   content: string;
   text?: string;
-
   onClick: React.ReactEventHandler;
 }
 
@@ -28,7 +26,7 @@ export default function Modal({
   return (
     <Dialog
       open={open}
-      onClick={onClick}
+      onClose={onClick}
     >
       <DialogTitle data-testid="title" >
         {title}

--- a/app-admin/src/components/ReservationsList/index.test.tsx
+++ b/app-admin/src/components/ReservationsList/index.test.tsx
@@ -14,6 +14,8 @@ describe('LoginFormContainer', () => {
         reservations={reservations}
         columns={columns}
         onChange={() => {}}
+        onClick={() => {}}
+        open={false}
       />,
     );
 

--- a/app-admin/src/components/ReservationsList/index.tsx
+++ b/app-admin/src/components/ReservationsList/index.tsx
@@ -25,7 +25,10 @@ const StyledPaper = styled(Paper)({
   marginTop: '4rem',
 });
 
-const ContentRow = styled(TableRow)(({ backgroundcolor, color }: { backgroundcolor?: string, color?: string }) => ({
+const ContentRow = styled(TableRow)(({
+  backgroundcolor,
+  color,
+}: { backgroundcolor?: string, color?: string }) => ({
   backgroundColor: backgroundcolor ?? '#FFFFFF',
 
   'td, button': {
@@ -33,14 +36,25 @@ const ContentRow = styled(TableRow)(({ backgroundcolor, color }: { backgroundcol
   },
 }));
 
-export default function ReservationsList({ reservations, columns, pagination, onChange }: Props) {
+export default function ReservationsList({
+  reservations,
+  columns,
+  pagination,
+  onChange,
+  onClick }: Props) {
   const { totalPages } = pagination;
 
-  const statuses: { [key: string]: { text: string, backgroundColor?: string, color?: string }; } = {
+  const statuses: { [key: string]: {
+    text: string,
+    backgroundColor?: string,
+    color?: string }
+  } = {
     'RESERVED': { text: '예약 완료' },
     'CANCELED': { text: '예약 취소', backgroundColor: '#D5D5D5' },
     'RETROSPECTIVE_WAITING': { text: '회고작성 전' },
-    'RETROSPECTIVE_COMPLETE': { text: '회고작성 완료', backgroundColor: '#10B5E8', color: '#FFFFFF' },
+    'RETROSPECTIVE_COMPLETE': { text: '상세보기',
+      backgroundColor: '#10B5E8',
+      color: '#FFFFFF' },
   };
 
   return (
@@ -63,7 +77,12 @@ export default function ReservationsList({ reservations, columns, pagination, on
             </TableHead>
 
             <TableBody>
-              {reservations.map(({ id, date, status, user: { name } }) => {
+              {reservations.map(({
+                id,
+                date,
+                status,
+                content,
+                user: { name } }) => {
                 const { text, backgroundColor, color } = statuses[status];
 
                 const waiting = status === 'RETROSPECTIVE_WAITING';
@@ -78,10 +97,13 @@ export default function ReservationsList({ reservations, columns, pagination, on
                     <TableCell align="center">{name}</TableCell>
                     <TableCell align="center">{date}</TableCell>
                     <TableCell align="center">
-                      <Button disabled={canceled} >상세보기</Button>
+                      <Button disabled={canceled} >{content}</Button>
                     </TableCell>
                     <TableCell align="center">
-                      <Button disabled={waiting || canceled}>
+                      <Button
+                        onClick={() => onClick(id)}
+                        disabled={waiting || canceled}
+                      >
                         {text}
                       </Button>
                     </TableCell>
@@ -93,7 +115,10 @@ export default function ReservationsList({ reservations, columns, pagination, on
             <TableFooter>
               <TableRow>
                 <TableCell align="center">
-                  <Pagination count={totalPages} onChange={onChange} color="primary" />
+                  <Pagination
+                    count={totalPages}
+                    onChange={onChange}
+                    color="primary" />
                 </TableCell>
               </TableRow>
             </TableFooter>

--- a/app-admin/src/components/ReservationsList/typings.ts
+++ b/app-admin/src/components/ReservationsList/typings.ts
@@ -26,5 +26,6 @@ export interface Props {
   reservations: Reservation[];
   columns: Column[];
   pagination: Pagination;
-  onChange: (e: React.ChangeEvent<unknown>, value: number)=> void;
+  onChange: (e: React.ChangeEvent<unknown>, value: number) => void;
+  onClick: React.ReactEventHandler
 }

--- a/app-admin/src/components/ReservationsList/typings.ts
+++ b/app-admin/src/components/ReservationsList/typings.ts
@@ -26,6 +26,7 @@ export interface Props {
   reservations: Reservation[];
   columns: Column[];
   pagination: Pagination;
-  onChange: (e: React.ChangeEvent<unknown>, value: number) => void;
-  onClick: React.ReactEventHandler
+  open: boolean;
+  onChange: (e: React.ChangeEvent<unknown>, value: number)=> void;
+  onClick: (id: number)=> void;
 }

--- a/app-admin/src/redux/retrospectivesSlice.ts
+++ b/app-admin/src/redux/retrospectivesSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface RetrospectivesState {
+  retrospectives: string;
+  isOpenRetrospectivesModal: boolean;
+}
+
+export const initialState: RetrospectivesState = {
+  retrospectives: '',
+  isOpenRetrospectivesModal: false,
+};
+
+const { actions, reducer } = createSlice({
+  name: 'retrospectives',
+  initialState,
+  reducers: {
+    viewRetrospectives: (state, { payload }) => ({
+      ...state,
+      retrospectives: payload,
+    }),
+    toggleRetrospectivesModal: (state) => ({
+      ...state,
+      isOpenRetrospectivesModal: !state.isOpenRetrospectivesModal,
+    }),
+  },
+});
+
+export const {
+  viewRetrospectives,
+  toggleRetrospectivesModal,
+} = actions;
+
+export default reducer;

--- a/app-admin/src/redux/retrospectivesSlice.ts
+++ b/app-admin/src/redux/retrospectivesSlice.ts
@@ -1,33 +1,53 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { getRetrospectives } from '../service/retrospectives';
+
+import { AppDispatch } from '../store';
+
+import { AxiosError } from 'axios';
+
 interface RetrospectivesState {
-  retrospectives: string;
-  isOpenRetrospectivesModal: boolean;
+  content: string;
+  showRetrospectivesModal: boolean;
 }
 
 export const initialState: RetrospectivesState = {
-  retrospectives: '',
-  isOpenRetrospectivesModal: false,
+  content: '',
+  showRetrospectivesModal: false,
 };
 
 const { actions, reducer } = createSlice({
   name: 'retrospectives',
   initialState,
   reducers: {
-    viewRetrospectives: (state, { payload }) => ({
+    saveDetailRetrospectives: (state, { payload }) => ({
       ...state,
-      retrospectives: payload,
+      content: payload,
+      showRetrospectivesModal: true,
     }),
     toggleRetrospectivesModal: (state) => ({
       ...state,
-      isOpenRetrospectivesModal: !state.isOpenRetrospectivesModal,
+      showRetrospectivesModal: !state.showRetrospectivesModal,
     }),
   },
 });
 
 export const {
-  viewRetrospectives,
+  saveDetailRetrospectives,
   toggleRetrospectivesModal,
 } = actions;
+
+export const loadRetrospectives = (id: number) => {
+  return async (dispatch: AppDispatch) => {
+    try {
+      const { content } = await getRetrospectives(id);
+
+      dispatch(saveDetailRetrospectives(content));
+    } catch (error) {
+      const response = (error as AxiosError).response;
+      alert(response!.data);
+    }
+  };
+};
 
 export default reducer;

--- a/app-admin/src/service/reservations.ts
+++ b/app-admin/src/service/reservations.ts
@@ -10,4 +10,4 @@ export const getReservations = async ({ page, size }: { page: number; size: numb
   return data;
 };
 
-export const x = () => {};
+export const x = () => { };

--- a/app-admin/src/service/retrospectives.ts
+++ b/app-admin/src/service/retrospectives.ts
@@ -1,0 +1,13 @@
+import { httpClient } from './api';
+
+import { loadItem } from '../services/storage';
+
+export const getRetrospectives = async (id: number) => {
+  const accessToken = loadItem('accessToken');
+
+  const { data } = await httpClient.get(`admin/reservations/${id}/retrospectives`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  return data;
+};

--- a/app-admin/src/store.ts
+++ b/app-admin/src/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import reservationsReudcer from './redux/reservationsSlice';
+import retrospectivesReducer from './redux/retrospectivesSlice';
 import authSlice from './redux/authSlice';
 
 export const store = configureStore({
   reducer: {
     reservations: reservationsReudcer,
+    retrospectives: retrospectivesReducer,
     auth: authSlice,
   },
 });


### PR DESCRIPTION
회고 상세보기를 구현했습니다.

예약 내역 페이지에서 회고 상세보기 버튼을 클릭하면 모달로 작성한 회고 내역이 보여집니다.

<img width="686" alt="image" src="https://user-images.githubusercontent.com/59111836/198586717-af1be2bd-59b6-4f7f-b4e2-98495e27e12f.png">
