### PR TITLE
로그인이 실패해도 예약 내역 페이지로 이동하던 이슈를 수정하라

### DIFF
--- a/app-admin/src/Containers/LoginFormContainer/index.tsx
+++ b/app-admin/src/Containers/LoginFormContainer/index.tsx
@@ -1,32 +1,52 @@
-import LoginForm from '../../components/LoginForm';
+import { useEffect } from 'react';
+
+import { useNavigate } from 'react-router-dom';
 
 import { useSelector } from 'react-redux';
+
+import { useAppDispatch } from '../../hooks';
+
+import { RootState } from '../../store';
 
 import {
   requestLogin,
   changeLoginField,
+  setErrorMessage,
 } from '../../redux/authSlice';
 
-
-import { RootState } from '../../store';
-import { useAppDispatch } from '../../hooks';
-import { useNavigate } from 'react-router-dom';
+import LoginForm from '../../components/LoginForm';
 
 const LoginFormContainer = () => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
-  const { loginFields: { email, password } } = useSelector((state: RootState) => state.auth);
+  const {
+    loginFields: { email, password },
+    errorMessage,
+    accessToken,
+  } = useSelector((state: RootState) => state.auth);
 
   const onChange = ({ name, value }: { name: string, value: string }) => {
     dispatch(changeLoginField({ name, value }));
   };
 
-  const handleSubmit: React.MouseEventHandler<HTMLButtonElement> = async () => {
-    await dispatch(requestLogin());
-
-    navigate('reservations');
+  const handleSubmit: React.MouseEventHandler<HTMLButtonElement> = () => {
+    dispatch(requestLogin());
   };
+
+  useEffect(() => {
+    if (errorMessage) {
+      alert(errorMessage);
+    }
+
+    if (accessToken) {
+      navigate('reservations');
+    }
+
+    return () => {
+      dispatch(setErrorMessage(''));
+    };
+  }, [errorMessage, accessToken]);
 
   return (
     <LoginForm

--- a/app-admin/src/Containers/LoginFormContainer/index.tsx
+++ b/app-admin/src/Containers/LoginFormContainer/index.tsx
@@ -42,11 +42,13 @@ const LoginFormContainer = () => {
     if (accessToken) {
       navigate('reservations');
     }
+  }, [errorMessage, accessToken]);
 
+  useEffect(() => {
     return () => {
       dispatch(setErrorMessage(''));
     };
-  }, [errorMessage, accessToken]);
+  }, [errorMessage]);
 
   return (
     <LoginForm

--- a/app-admin/src/redux/authSlice.tsx
+++ b/app-admin/src/redux/authSlice.tsx
@@ -1,6 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
+
 import { postLogin } from '../service/auth';
 import { saveItem } from '../services/storage';
+
 import { AppDispatch, RootState } from '../store';
 
 export interface LoginFields {
@@ -11,6 +13,7 @@ export interface LoginFields {
 interface LoginState {
   loginFields: LoginFields;
   accessToken: string;
+  errorMessage: string;
 }
 
 const initialState: LoginState = {
@@ -19,6 +22,7 @@ const initialState: LoginState = {
     password: '',
   },
   accessToken: '',
+  errorMessage: '',
 };
 
 const { reducer, actions } = createSlice({
@@ -40,26 +44,34 @@ const { reducer, actions } = createSlice({
         accessToken: payload,
       };
     },
+    setErrorMessage: (state, { payload }) => {
+      return {
+        ...state,
+        errorMessage: payload,
+      };
+    },
   },
 });
 
 export const {
   changeLoginField,
   setAccessToken,
+  setErrorMessage,
 } = actions;
 
 export const requestLogin = () => {
   return async (dispatch: AppDispatch, getState: ()=> RootState) => {
     const { loginFields: { email, password } } = getState().auth;
 
-    await postLogin({ email, password })
-      .then(({ accessToken }) => {
-        saveItem('accessToken', accessToken);
+    try {
+      const accessToken = await postLogin({ email, password });
 
-        dispatch(setAccessToken(accessToken));
-      }).catch((error) => {
-        alert(error.response.data);
-      });
+      saveItem('accessToken', accessToken);
+
+      dispatch(setAccessToken(accessToken));
+    } catch (error) {
+      dispatch(setErrorMessage('아이디와 비밀번호를 확인해주세요.'));
+    }
   };
 };
 

--- a/app-admin/src/service/auth.ts
+++ b/app-admin/src/service/auth.ts
@@ -5,7 +5,7 @@ import { LoginFields } from '../redux/authSlice';
 export const postLogin = async ({ email, password }: LoginFields) => {
   const { data } = await httpClient.post('/login', { email, password });
 
-  return data;
+  return data.accessToken;
 };
 
 export const x = () => { };


### PR DESCRIPTION
기존 로그인이 실패해도 예약 내역 페이지로 이동하던 이슈를 수정하기 위해 다음과 같이 조치를 취했습니다.

1. `errorMessage` 상태를 정의하여 로그인이 실패하면 `errorMessage` 를 저장합니다.
2. `LoginFormContainer`에서는 리덕스에 있는 `errorMessage` 와 `accessToken` 값의 변화를 감지하여
`errorMessage` 에 변경이 감지되면 에러 메세지를 띄우고 `accessToken`의 변경이 감지되면 예약 내역 페이지로 이동합니다.
3.  페이지를 벗어나면 클린업을 통해 `errorMessage`를 초기화합니다.