### PR TITLE
올바르게 에러처리를 하고 요청이 실패했다면 로그인 페이지로 돌아가라

### DIFF
--- a/app-admin/src/Containers/ReservationsContainer/index.tsx
+++ b/app-admin/src/Containers/ReservationsContainer/index.tsx
@@ -1,8 +1,14 @@
 import { useEffect } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import { useAppDispatch, useAppSelector } from '../../hooks';
 
-import { loadReservations, savePage } from '../../redux/reservationsSlice';
+import {
+  loadReservations,
+  savePage,
+  setErrorMessage,
+} from '../../redux/reservationsSlice';
 
 import ReservationsList from '../../components/ReservationsList';
 
@@ -16,11 +22,13 @@ import {
 } from '../../redux/retrospectivesSlice';
 
 export default function ReserVationsContainer() {
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
   const {
     pagination,
     reservations,
+    errorMessage,
   } = useAppSelector((store) => store.reservations);
 
   const {
@@ -40,13 +48,26 @@ export default function ReserVationsContainer() {
     dispatch(loadRetrospectives(id));
   };
 
+  const modalHandler = () => {
+    dispatch(toggleRetrospectivesModal());
+  };
+
   useEffect(() => {
     dispatch(loadReservations());
   }, [page]);
 
-  const modalHandler = () => {
-    dispatch(toggleRetrospectivesModal());
-  };
+  useEffect(() => {
+    if (errorMessage) {
+      alert(errorMessage);
+      navigate('/');
+    }
+  }, [errorMessage]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(setErrorMessage(''));
+    };
+  }, [errorMessage]);
 
   return (
     <>

--- a/app-admin/src/redux/reservationsSlice.ts
+++ b/app-admin/src/redux/reservationsSlice.ts
@@ -1,14 +1,20 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { AxiosError } from 'axios';
+
 import { AppDispatch, RootState } from './../store';
 
 import { getReservations } from '../service/reservations';
 
-import { Pagination, Reservation } from '../components/ReservationsList/typings';
+import {
+  Pagination,
+  Reservation,
+} from '../components/ReservationsList/typings';
 
 interface ReservationsState {
   pagination: Pagination;
   reservations: Reservation[];
+  errorMessage: string;
 }
 
 export const initialState: ReservationsState = {
@@ -18,6 +24,7 @@ export const initialState: ReservationsState = {
     totalPages: 1,
   },
   reservations: [],
+  errorMessage: '',
 };
 
 const { actions, reducer } = createSlice({
@@ -39,6 +46,10 @@ const { actions, reducer } = createSlice({
       ...state,
       reservations: payload,
     }),
+    setErrorMessage: (state, { payload }) => ({
+      ...state,
+      errorMessage: payload,
+    }),
   },
 });
 
@@ -46,6 +57,7 @@ export const {
   savePagination,
   savePage,
   saveReservations,
+  setErrorMessage,
 } = actions;
 
 export function loadReservations() {
@@ -58,7 +70,17 @@ export function loadReservations() {
       dispatch(savePagination(pagination));
       dispatch(saveReservations(reservations));
     } catch (error) {
-      alert('정보가 없습니다');
+      const status = (error as AxiosError).response?.status;
+
+      if (status === 403) {
+        return dispatch(setErrorMessage('권한이 없습니다.'));
+      }
+
+      if (status === 401) {
+        return dispatch(setErrorMessage('로그인 후 이용해주세요.'));
+      }
+
+      dispatch(setErrorMessage('예기치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'));
     }
   };
 }


### PR DESCRIPTION
예약 내역 요청을 실패했음에도 불구하고 예약 내역 페이지에 남아있는 오류를 수정하기 위해 다음과 같이 조치를 취했습니다.

1. `errorMessage` 상태를 정의하고 예약 내역 요청이 실패하면 `errorMessage`를 저장합니다.
2. `ReservationsContainer`에서는 리덕스에 있는 `errorMessage`의 변화를 감지되면 `errorMessage`를 띄우고 로그인 페이지로 돌아갑니다.