### PR TITLE
관리자 예약내역 화면의 망가지는 css 수정하라

### DIFF
--- a/app-admin/src/components/ReservationsList/index.tsx
+++ b/app-admin/src/components/ReservationsList/index.tsx
@@ -94,12 +94,14 @@ export default function ReservationsList({
                     backgroundcolor={backgroundColor}
                     color={color}
                   >
-                    <TableCell align="center">{name}</TableCell>
-                    <TableCell align="center">{date}</TableCell>
-                    <TableCell align="center">
+                    <TableCell sx={{ width: '20%' }} align="center">{date}</TableCell>
+                    <TableCell sx={{ width: '10%' }} align="center">{name}</TableCell>
+                    <TableCell sx={{ width: '60%' }} align="center">
                       <Button disabled={canceled} >{content}</Button>
                     </TableCell>
-                    <TableCell align="center">
+                    <TableCell
+                      sx={{ width: '10%' }}
+                      align="center">
                       <Button
                         onClick={() => onClick(id)}
                         disabled={waiting || canceled}

--- a/app-admin/src/data/columns.ts
+++ b/app-admin/src/data/columns.ts
@@ -1,9 +1,9 @@
 const columns = [{
   id: 1,
-  label: '이름',
+  label: '에약 날짜',
 }, {
   id: 2,
-  label: '예약 날짜',
+  label: '이름',
 }, {
   id: 3,
   label: '계획',


### PR DESCRIPTION
### 기존에는 예약화면의 css가 보기 불편한 상황이있었습니다
- 예약내역의 계획내용 양의 따라 페이징이 망가지는현상
- width가 정해져있지않아 예약날짜, 회고확인 버튼등 줄바꿈되던현상

이 문제점들을 수정하기위해 각각 TableCell 컴포넌트의 width를 % 로 맞춰 수정했습니다

### 기존에는 이름, 예약날짜 순으로 내역을 보여줬었습니다.
지영님이 날짜가 보이면 더 좋겠다는 건의로 저와 종혁님도 날짜가 먼저 보이는게 깔끔하다고생각해 예약날짜를 먼저 볼수있게끔 수정했습니다

### 기존화면
![image](https://user-images.githubusercontent.com/57708817/199060087-c4415401-eb46-42db-b79e-8b32953d415e.png)
### 수정화면
![image](https://user-images.githubusercontent.com/57708817/199060065-31e3176a-cacf-42df-9519-829f2f019bdf.png)