### PR TITLE
의존성 목록 설치 부분에서 -f 옵션을 빼라

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ docker-compose down
 
 ### 1. 의존성 목록 설치
 ```bash
-npm ci -f
+npm ci
 ```
 
 ### 2. 서버 실행


### PR DESCRIPTION
기존에는 리액트 버전이 호환되지 않는 의존성이 있어서 -f 옵션이 필요했으나, 이제는 해당 옵션 없이 의존성 설치가 가능해졌습니다.
따라서 README에서 해당 부분을 수정했습니다.